### PR TITLE
cleanup and fix the example tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ import (
 )
 
 func main() {
-	logHandler := slog.NewTextHandler(os.Stdout, nil)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	script := `
 		// The ctx object from the Go inputData map
-		name := ctx.get("name", "Roberto")
+		name := ctx["name"]
 
 		p := "."
 		if ctx.get("excited") {
@@ -73,7 +73,7 @@ func main() {
 	evaluator, _ := polyscript.FromRisorStringWithData(
 		script,
 		inputData,
-		logHandler,
+		logger.Handler(),
 	)
 	
 	ctx := context.Background()
@@ -102,7 +102,7 @@ However, when using `StaticProvider`, each evaluation will always use the same i
 The `ContextProvider` retrieves dynamic data from the context object sent to Eval. This is useful when input data changes at runtime:
 
 ```go
-evaluator, _ := polyscript.FromRisorString(script, logHandler)
+evaluator, _ := polyscript.FromRisorString(script, logger.Handler())
 
 ctx := context.Background()
 runtimeData := map[string]any{"name": "Billie Jean", "relationship": false}
@@ -123,7 +123,7 @@ staticData := map[string]any{
 }
 
 // Create the evaluator with the static data
-evaluator, _ := polyscript.FromRisorStringWithData(script, staticData, logHandler)
+evaluator, _ := polyscript.FromRisorStringWithData(script, staticData, logger.Handler())
 
 // For each request, prepare dynamic data
 requestData := map[string]any{"userId": 123}
@@ -183,7 +183,7 @@ staticData := map[string]any{"name": "World"}
 evaluator, err := polyscript.FromStarlarkStringWithData(
     scriptContent,
     staticData,
-    logHandler,
+    logger.Handler(),
 )
 
 // Execute with a context
@@ -200,7 +200,7 @@ staticData := map[string]any{"input": "World"}
 evaluator, err := polyscript.FromExtismFileWithData(
     "/path/to/module.wasm",
     staticData,
-    logHandler,
+    logger.Handler(),
     "greet",  // entryPoint
 )
 

--- a/examples/data-prep/risor/main_test.go
+++ b/examples/data-prep/risor/main_test.go
@@ -81,7 +81,30 @@ func TestEvalAndExtractResult(t *testing.T) {
 	assert.NotNil(t, result, "Result should not be nil")
 
 	// Check basic result fields
-	assert.Contains(t, result, "greeting", "Result should contain a greeting")
+	assert.Contains(t,
+		result, "greeting",
+		"Result should contain a greeting")
+
+	// Verify actual dynamic data is returned, not the fallback values
+	greeting := result["greeting"]
+	require.IsType(t, "", greeting, "Greeting should be a string")
+	assert.Equal(t,
+		"Hello, World!", greeting,
+		"Should use actual name 'World', not fallback 'Default'")
+
+	userID := result["user_id"]
+	require.IsType(t, "", userID, "user_id should be a string")
+	assert.Equal(t,
+		"user-123", userID,
+		"Should use actual user_id, not fallback 'unknown'")
+
+	timestamp := result["timestamp"]
+	require.IsType(t,
+		"", timestamp,
+		"timestamp should be a string")
+	assert.NotEqual(t,
+		"Unknown", timestamp,
+		"Should use actual timestamp, not fallback 'Unknown'")
 }
 
 // TestFullExecution tests the entire execution flow as an integration test
@@ -110,4 +133,32 @@ func TestFullExecution(t *testing.T) {
 	assert.Contains(t, result, "greeting", "Result should have greeting")
 	assert.Contains(t, result, "user_id", "Result should have user_id")
 	assert.Contains(t, result, "app_info", "Result should have app_info")
+
+	// Verify the dynamic data is returned, not the fallback values
+	greeting := result["greeting"]
+	require.IsType(t, "", greeting, "Greeting should be a string")
+	assert.Equal(
+		t,
+		"Hello, World!",
+		greeting,
+		"Should use actual name 'World', not fallback 'Default'",
+	)
+
+	userID := result["user_id"]
+	require.IsType(t, "", userID, "user_id should be a string")
+	assert.Equal(t, "user-123", userID, "Should use actual user_id, not fallback 'unknown'")
+
+	timestamp := result["timestamp"]
+	require.IsType(t, "", timestamp, "timestamp should be a string")
+	assert.NotEqual(t, "Unknown", timestamp, "Should use actual timestamp, not fallback 'Unknown'")
+
+	message := result["message"]
+	require.IsType(t, "", message, "message should be a string")
+	assert.Contains(
+		t,
+		message,
+		"admin",
+		"Should use actual user role 'admin', not fallback 'guest'",
+	)
+	assert.NotContains(t, message, "guest", "Should not contain fallback role 'guest'")
 }

--- a/examples/data-prep/risor/testdata/script.risor
+++ b/examples/data-prep/risor/testdata/script.risor
@@ -1,27 +1,24 @@
 // Wrap everything in a function for Risor syntax
 func process() {
-    // Script has access to ctx variable passed from Go
-    // Access data with fallbacks for compatibility with both patterns
-    input_data := ctx.get("input_data", {})
     
     // Access static config data (set at compile time)
     app_version := ctx.get("app_version", "unknown")
     environment := ctx.get("environment", "unknown")
     config := ctx.get("config", {})
     
-    // Get name from runtime data
-    name := input_data.get("name", "Default")
+    // Get name from runtime data (added via AddDataToContext)
+    name := ctx.get("name", "Default")
     
     // Get timestamp from runtime data
-    timestamp := input_data.get("timestamp", "Unknown")
+    timestamp := ctx.get("timestamp", "Unknown")
     
     // Process user data from runtime data
-    user_data := input_data.get("user_data", {})
+    user_data := ctx.get("user_data", {})
     user_role := user_data.get("role", "guest")
     user_id := user_data.get("id", "unknown")
     
     // Access request data if available
-    request := input_data.get("request", {})
+    request := ctx.get("request", {})
     request_method := request.get("Method", "")
     request_path := request.get("URL_Path", "")
     

--- a/examples/data-prep/starlark/main_test.go
+++ b/examples/data-prep/starlark/main_test.go
@@ -83,12 +83,27 @@ func TestEvalAndExtractResult(t *testing.T) {
 	assert.Contains(t, result, "greeting", "Result should contain a greeting")
 	assert.Contains(t, result, "app_info", "Result should contain app info")
 
+	// Verify actual dynamic data is used, not fallback values
+	greeting := result["greeting"]
+	require.IsType(t, "", greeting, "Greeting should be a string")
+	assert.Equal(t,
+		"Hello, World!", greeting,
+		"Should use actual name 'World', not fallback 'Default'")
+
+	userID := result["user_id"]
+	require.IsType(t, "", userID, "user_id should be a string")
+	assert.Equal(t, "user-123", userID, "Should use actual user_id, not fallback 'unknown'")
+
+	timestamp := result["timestamp"]
+	require.IsType(t, "", timestamp, "timestamp should be a string")
+	assert.NotEqual(t, "Unknown", timestamp, "Should use actual timestamp, not fallback 'Unknown'")
+
 	// Verify app info contains data from static provider
-	appInfo, hasAppInfo := result["app_info"].(map[string]any)
-	if assert.True(t, hasAppInfo, "app_info should be a map") {
-		assert.Equal(t, "1.0.0-test", appInfo["version"], "Should have correct app version")
-		assert.Equal(t, "test", appInfo["environment"], "Should have test environment")
-	}
+	appInfo := result["app_info"]
+	require.IsType(t, map[string]any{}, appInfo, "app_info should be a map")
+	appInfoMap := appInfo.(map[string]any)
+	assert.Equal(t, "1.0.0-test", appInfoMap["version"], "Should have correct app version")
+	assert.Equal(t, "test", appInfoMap["environment"], "Should have test environment")
 }
 
 // TestFullExecution tests the entire execution flow as an integration test
@@ -115,4 +130,32 @@ func TestFullExecution(t *testing.T) {
 	assert.Contains(t, result, "user_id", "Result should have user_id from dynamic data")
 	assert.Contains(t, result, "app_info", "Result should have app_info from static data")
 	assert.Contains(t, result, "request_info", "Result should have request_info from HTTP request")
+
+	// Verify the dynamic data is returned, not the fallback values
+	greeting := result["greeting"]
+	require.IsType(t, "", greeting, "Greeting should be a string")
+	assert.Equal(
+		t,
+		"Hello, World!",
+		greeting,
+		"Should use actual name 'World', not fallback 'Default'",
+	)
+
+	userID := result["user_id"]
+	require.IsType(t, "", userID, "user_id should be a string")
+	assert.Equal(t, "user-123", userID, "Should use actual user_id, not fallback 'unknown'")
+
+	timestamp := result["timestamp"]
+	require.IsType(t, "", timestamp, "timestamp should be a string")
+	assert.NotEqual(t, "Unknown", timestamp, "Should use actual timestamp, not fallback 'Unknown'")
+
+	message := result["message"]
+	require.IsType(t, "", message, "message should be a string")
+	assert.Contains(
+		t,
+		message,
+		"admin",
+		"Should use actual user role 'admin', not fallback 'guest'",
+	)
+	assert.NotContains(t, message, "guest", "Should not contain fallback role 'guest'")
 }

--- a/examples/data-prep/starlark/testdata/script.star
+++ b/examples/data-prep/starlark/testdata/script.star
@@ -1,26 +1,23 @@
 # Script has access to ctx variable passed from Go
 def process_data():
-    # Access data with fallbacks for compatibility with both patterns
-    input_data = ctx.get("input_data", {})
-    
     # Access static config data (set at compile time)
     app_version = ctx.get("app_version", "unknown")
     environment = ctx.get("environment", "unknown")
     config = ctx.get("config", {})
     
-    # Get name from runtime data
-    name = input_data.get("name", "Default")
+    # Get name from runtime data (added via AddDataToContext)
+    name = ctx.get("name", "Default")
     
     # Get timestamp from runtime data
-    timestamp = input_data.get("timestamp", "Unknown")
+    timestamp = ctx.get("timestamp", "Unknown")
     
     # Process user data from runtime data
-    user_data = input_data.get("user_data", {})
+    user_data = ctx.get("user_data", {})
     user_role = user_data.get("role", "guest")
     user_id = user_data.get("id", "unknown")
     
     # Access request data if available
-    request = input_data.get("request", {})
+    request = ctx.get("request", {})
     request_method = request.get("Method", "")
     request_path = request.get("URL_Path", "")
     

--- a/examples/multiple-instantiation/extism/main_test.go
+++ b/examples/multiple-instantiation/extism/main_test.go
@@ -22,13 +22,11 @@ func TestRunMultipleTimes(t *testing.T) {
 	for i, result := range results {
 		assert.NotNil(t, result, "Result at index %d should not be nil", i)
 
-		greeting, ok := result["greeting"]
-		require.True(t, ok, "Result at index %d should have a greeting field", i)
+		greeting := result["greeting"]
+		require.IsType(t, "", greeting, "Greeting at index %d should be a string", i)
 		assert.Equal(t, expectedResults[i], greeting,
 			"Result at index %d should have the correct greeting", i,
 		)
-
-		require.IsType(t, "", greeting, "Greeting at index %d should be a string", i)
 	}
 }
 

--- a/examples/multiple-instantiation/risor/main_test.go
+++ b/examples/multiple-instantiation/risor/main_test.go
@@ -45,13 +45,11 @@ func TestRunMultipleTimes(t *testing.T) {
 			result := results[i]
 			require.NotNil(t, result, "Result at index %d should not be nil", i)
 
-			greeting, exists := result["greeting"]
-			require.True(t, exists, "Result should have a greeting field")
+			greeting := result["greeting"]
 			require.IsType(t, "", greeting, "Greeting should be a string")
 			assert.Equal(t, expected.greeting, greeting, "Should have the correct greeting")
 
-			length, exists := result["length"]
-			require.True(t, exists, "Result should have a length field")
+			length := result["length"]
 			require.IsType(t, int64(0), length, "Length should be int64")
 			assert.Equal(t, expected.length, length, "Should have the correct length")
 		})

--- a/examples/multiple-instantiation/starlark/main_test.go
+++ b/examples/multiple-instantiation/starlark/main_test.go
@@ -46,13 +46,11 @@ func TestRunMultipleTimes(t *testing.T) {
 			result := results[i]
 			require.NotNil(t, result, "Result at index %d should not be nil", i)
 
-			greeting, exists := result["greeting"]
-			require.True(t, exists, "Result should have a greeting field")
+			greeting := result["greeting"]
 			require.IsType(t, "", greeting, "Greeting should be a string")
 			assert.Equal(t, expected.greeting, greeting, "Should have the correct greeting")
 
-			length, exists := result["length"]
-			require.True(t, exists, "Result should have a length field")
+			length := result["length"]
 			require.IsType(t, int64(0), length, "Length should be int64")
 			assert.Equal(t, expected.length, length, "Should have the correct length")
 		})

--- a/examples/simple/extism/main_test.go
+++ b/examples/simple/extism/main_test.go
@@ -12,8 +12,7 @@ func TestRunExtismExample(t *testing.T) {
 	require.NoError(t, err, "runExtismExample should not return an error")
 	require.NotNil(t, result, "Result should not be nil")
 
-	greeting, exists := result["greeting"]
-	require.True(t, exists, "Result should have a greeting field")
+	greeting := result["greeting"]
 	require.IsType(t, "", greeting, "Greeting should be a string")
 	assert.Equal(t, "Hello, World!", greeting, "Should have the correct greeting")
 }

--- a/examples/simple/risor/main_test.go
+++ b/examples/simple/risor/main_test.go
@@ -12,13 +12,11 @@ func TestRunRisorExample(t *testing.T) {
 	require.NoError(t, err, "runRisorExample should not return an error")
 	require.NotNil(t, result, "Result should not be nil")
 
-	greeting, exists := result["greeting"]
-	require.True(t, exists, "Result should have a greeting field")
+	greeting := result["greeting"]
 	require.IsType(t, "", greeting, "Greeting should be a string")
 	assert.Equal(t, "Hello, World!", greeting, "Should have the correct greeting")
 
-	length, exists := result["length"]
-	require.True(t, exists, "Result should have a length field")
+	length := result["length"]
 	require.IsType(t, int64(0), length, "Length should be int64")
 	assert.Equal(t, int64(13), length, "Should have the correct length")
 }

--- a/examples/simple/starlark/main_test.go
+++ b/examples/simple/starlark/main_test.go
@@ -12,13 +12,11 @@ func TestRunStarlarkExample(t *testing.T) {
 	require.NoError(t, err, "runStarlarkExample should not return an error")
 	require.NotNil(t, result, "Result should not be nil")
 
-	greeting, exists := result["greeting"]
-	require.True(t, exists, "Result should have a greeting field")
+	greeting := result["greeting"]
 	require.IsType(t, "", greeting, "Greeting should be a string")
 	assert.Equal(t, "Hello, World!", greeting, "Should have the correct greeting")
 
-	length, exists := result["length"]
-	require.True(t, exists, "Result should have a length field")
+	length := result["length"]
 	require.IsType(t, int64(0), length, "Length should be int64")
 	assert.Equal(t, int64(13), length, "Should have the correct length")
 }


### PR DESCRIPTION
previously, some of the example scripts were falling back to default values for data access, and the tests weren't catching this problem. This adjusts the tests and scripts to confirm the data access is correct.