### PR TITLE
fix starlark goroutine leak in exec() with context.AfterFunc

### DIFF
--- a/engines/starlark/evaluator/evaluator.go
+++ b/engines/starlark/evaluator/evaluator.go
@@ -112,11 +112,12 @@ func (be *Evaluator) exec(
 		},
 	}
 
-	// Set up cancellation from context
-	go func() {
-		<-ctx.Done()
+	// Set up cancellation from context using AfterFunc to avoid goroutine leak
+	// when context is never cancelled (e.g., context.Background())
+	stop := context.AfterFunc(ctx, func() {
 		thread.Cancel(ctx.Err().Error())
-	}()
+	})
+	defer stop()
 
 	// Execute the program
 	finalGlobals, err := prog.Init(thread, globals)

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -229,7 +229,9 @@ func TestEval_NoGoroutineLeak(t *testing.T) {
 
 	// Use context.Background() so ctx.Done() is nil — this is the exact scenario
 	// where a bare goroutine waiting on <-ctx.Done() would block forever and leak.
+	// t.Context() would defeat the test by giving a cancellable context.
 	for range 100 {
+		//nolint:usetesting // intentional — see comment above
 		ctx := context.WithValue(context.Background(), constants.EvalData, map[string]any{})
 		_, err := evaluator.Eval(ctx)
 		require.NoError(t, err)

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/robbyt/go-polyscript/engines/starlark/compiler"
@@ -213,6 +214,31 @@ invalid_func()
 			require.Equal(t, "starlark.Evaluator", evaluator.String())
 		})
 	})
+}
+
+// TestEval_NoGoroutineLeak verifies that Eval() with a non-cancellable context does not leak goroutines
+func TestEval_NoGoroutineLeak(t *testing.T) {
+	t.Parallel()
+	scriptContent := `_ = 1 + 1`
+	_, evaluator := evalBuilder(t, scriptContent)
+
+	// Record baseline goroutine count
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	// Run 100 evaluations with a context that won't be cancelled during Eval()
+	for range 100 {
+		ctx := context.WithValue(t.Context(), constants.EvalData, map[string]any{})
+		_, err := evaluator.Eval(ctx)
+		require.NoError(t, err)
+	}
+
+	// Allow goroutines to settle
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	growth := after - before
+	require.Less(t, growth, 5, "goroutine count grew by %d after 100 Eval() calls; suspected leak", growth)
 }
 
 // TestEvaluator_AddDataToContext tests the AddDataToContext method with various scenarios

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -216,9 +216,10 @@ invalid_func()
 	})
 }
 
-// TestEval_NoGoroutineLeak verifies that Eval() with a non-cancellable context does not leak goroutines
+// TestEval_NoGoroutineLeak verifies that Eval() with a non-cancellable context does not leak goroutines.
+// Not parallelised on purpose — runtime.NumGoroutine() reads the process-wide goroutine count, so
+// concurrent tests would perturb the baseline and make the assertion flaky.
 func TestEval_NoGoroutineLeak(t *testing.T) {
-	t.Parallel()
 	scriptContent := `_ = 1 + 1`
 	_, evaluator := evalBuilder(t, scriptContent)
 
@@ -226,9 +227,10 @@ func TestEval_NoGoroutineLeak(t *testing.T) {
 	runtime.GC()
 	before := runtime.NumGoroutine()
 
-	// Run 100 evaluations with a context that won't be cancelled during Eval()
+	// Use context.Background() so ctx.Done() is nil — this is the exact scenario
+	// where a bare goroutine waiting on <-ctx.Done() would block forever and leak.
 	for range 100 {
-		ctx := context.WithValue(t.Context(), constants.EvalData, map[string]any{})
+		ctx := context.WithValue(context.Background(), constants.EvalData, map[string]any{})
 		_, err := evaluator.Eval(ctx)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
## Summary

Every `Eval()` call on the Starlark evaluator spawned a goroutine that blocked on `<-ctx.Done()` to interrupt the running thread on cancellation. With non-cancellable contexts (e.g. `context.Background()`), those goroutines never exited and accumulated unboundedly.

This swaps the bare goroutine for `context.AfterFunc`, which registers a callback and returns a stop function. We `defer stop()` so the callback is unregistered as soon as the script completes — no leak, regardless of whether the context is cancellable.

## Changes

- `engines/starlark/evaluator/evaluator.go` — replace the goroutine in `exec()` with `context.AfterFunc(ctx, thread.Cancel)` plus `defer stop()`.
- `engines/starlark/evaluator/evaluator_test.go` — new `TestEval_NoGoroutineLeak` regression test: runs 100 evaluations with a non-cancellable context and asserts the goroutine count doesn't grow.

## Test plan

- [x] `go test -race ./engines/starlark/...` passes locally
- [x] CI green