### PR TITLE
extract loadInputData and AddDataToContext helpers to platform/data

### DIFF
--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -203,17 +203,5 @@ func (be *Evaluator) AddDataToContext(
 	ctx context.Context,
 	d ...map[string]any,
 ) (context.Context, error) {
-	logger := be.logger.WithGroup("AddDataToContext")
-
-	// Use the shared helper function for context preparation
-	if be.execUnit == nil || be.execUnit.GetDataProvider() == nil {
-		return ctx, fmt.Errorf("no data provider available")
-	}
-
-	return data.AddDataToContextHelper(
-		ctx,
-		logger,
-		be.execUnit.GetDataProvider(),
-		d...,
-	)
+	return data.AddDataToContextFromProvider(ctx, be.logger.WithGroup("AddDataToContext"), be.getDataProvider(), d...)
 }

--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -43,29 +43,18 @@ func (be *Evaluator) String() string {
 	return "extism.Evaluator"
 }
 
+// getDataProvider returns the data provider from the executable unit, or nil if unavailable.
+func (be *Evaluator) getDataProvider() data.Provider {
+	if be.execUnit == nil {
+		return nil
+	}
+	return be.execUnit.GetDataProvider()
+}
+
 // loadInputData retrieves input data using the data provider in the executable unit.
 // Returns a map that will be used as input for the WASM module.
 func (be *Evaluator) loadInputData(ctx context.Context) (map[string]any, error) {
-	logger := be.logger.WithGroup("loadInputData")
-
-	// If no executable unit or data provider, return empty map
-	if be.execUnit == nil || be.execUnit.GetDataProvider() == nil {
-		logger.WarnContext(ctx, "no data provider available, using empty data")
-		return make(map[string]any), nil
-	}
-
-	// Get input data from provider
-	inputData, err := be.execUnit.GetDataProvider().GetData(ctx)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to get input data from provider", "error", err)
-		return nil, err
-	}
-
-	if len(inputData) == 0 {
-		logger.WarnContext(ctx, "empty input data returned from provider")
-	}
-	logger.DebugContext(ctx, "input data loaded from provider", "inputData", inputData)
-	return inputData, nil
+	return data.LoadInputData(ctx, be.logger.WithGroup("loadInputData"), be.getDataProvider())
 }
 
 // execHelper is a utility function to handle common execution logic

--- a/engines/risor/evaluator/evaluator.go
+++ b/engines/risor/evaluator/evaluator.go
@@ -52,29 +52,18 @@ func (be *Evaluator) String() string {
 	return "risor.Evaluator"
 }
 
+// getDataProvider returns the data provider from the executable unit, or nil if unavailable.
+func (be *Evaluator) getDataProvider() data.Provider {
+	if be.execUnit == nil {
+		return nil
+	}
+	return be.execUnit.GetDataProvider()
+}
+
 // loadInputData retrieves input data using the data provider in the executable unit.
 // Returns a map that will be used as input for the Risor engine.
 func (be *Evaluator) loadInputData(ctx context.Context) (map[string]any, error) {
-	logger := be.logger.WithGroup("loadInputData")
-
-	// If no executable unit or data provider, return empty map
-	if be.execUnit == nil || be.execUnit.GetDataProvider() == nil {
-		logger.WarnContext(ctx, "no data provider available, using empty data")
-		return make(map[string]any), nil
-	}
-
-	// Get input data from provider
-	inputData, err := be.execUnit.GetDataProvider().GetData(ctx)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to get input data from provider", "error", err)
-		return nil, err
-	}
-
-	if len(inputData) == 0 {
-		logger.WarnContext(ctx, "empty input data returned from provider")
-	}
-	logger.DebugContext(ctx, "input data loaded from provider", "inputData", inputData)
-	return inputData, nil
+	return data.LoadInputData(ctx, be.logger.WithGroup("loadInputData"), be.getDataProvider())
 }
 
 // exec runs the bytecode with the provided environment map

--- a/engines/risor/evaluator/evaluator.go
+++ b/engines/risor/evaluator/evaluator.go
@@ -161,17 +161,5 @@ func (be *Evaluator) AddDataToContext(
 	ctx context.Context,
 	d ...map[string]any,
 ) (context.Context, error) {
-	logger := be.logger.WithGroup("AddDataToContext")
-
-	// Use the shared helper function for context preparation
-	if be.execUnit == nil || be.execUnit.GetDataProvider() == nil {
-		return ctx, fmt.Errorf("no data provider available")
-	}
-
-	return data.AddDataToContextHelper(
-		ctx,
-		logger,
-		be.execUnit.GetDataProvider(),
-		d...,
-	)
+	return data.AddDataToContextFromProvider(ctx, be.logger.WithGroup("AddDataToContext"), be.getDataProvider(), d...)
 }

--- a/engines/starlark/evaluator/evaluator.go
+++ b/engines/starlark/evaluator/evaluator.go
@@ -54,29 +54,18 @@ func (be *Evaluator) String() string {
 	return "starlark.Evaluator"
 }
 
+// getDataProvider returns the data provider from the executable unit, or nil if unavailable.
+func (be *Evaluator) getDataProvider() data.Provider {
+	if be.execUnit == nil {
+		return nil
+	}
+	return be.execUnit.GetDataProvider()
+}
+
 // loadInputData retrieves input data using the data provider in the executable unit.
 // Returns a map that will be used as input for the Starlark engine.
 func (be *Evaluator) loadInputData(ctx context.Context) (map[string]any, error) {
-	logger := be.logger.WithGroup("loadInputData")
-
-	// If no executable unit or data provider, return empty map
-	if be.execUnit == nil || be.execUnit.GetDataProvider() == nil {
-		logger.WarnContext(ctx, "no data provider available, using empty data")
-		return make(map[string]any), nil
-	}
-
-	// Get input data from provider
-	inputData, err := be.execUnit.GetDataProvider().GetData(ctx)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to get input data from provider", "error", err)
-		return nil, err
-	}
-
-	if len(inputData) == 0 {
-		logger.WarnContext(ctx, "empty input data returned from provider")
-	}
-	logger.DebugContext(ctx, "input data loaded from provider", "inputData", inputData)
-	return inputData, nil
+	return data.LoadInputData(ctx, be.logger.WithGroup("loadInputData"), be.getDataProvider())
 }
 
 // prepareGlobals merges the universe and input globals into a single Starlark dictionary

--- a/engines/starlark/evaluator/evaluator.go
+++ b/engines/starlark/evaluator/evaluator.go
@@ -217,17 +217,5 @@ func (be *Evaluator) AddDataToContext(
 	ctx context.Context,
 	d ...map[string]any,
 ) (context.Context, error) {
-	logger := be.logger.WithGroup("AddDataToContext")
-
-	// Use the shared helper function for context preparation
-	if be.execUnit == nil || be.execUnit.GetDataProvider() == nil {
-		return ctx, fmt.Errorf("no data provider available")
-	}
-
-	return data.AddDataToContextHelper(
-		ctx,
-		logger,
-		be.execUnit.GetDataProvider(),
-		d...,
-	)
+	return data.AddDataToContextFromProvider(ctx, be.logger.WithGroup("AddDataToContext"), be.getDataProvider(), d...)
 }

--- a/platform/data/addDataToContext.go
+++ b/platform/data/addDataToContext.go
@@ -43,3 +43,18 @@ func AddDataToContextHelper(
 
 	return enrichedCtx, err
 }
+
+// AddDataToContextFromProvider is a convenience wrapper that handles a nil provider
+// by returning a clear error, then delegates to AddDataToContextHelper.
+// This consolidates the nil-check + delegation pattern duplicated across all engine evaluators.
+func AddDataToContextFromProvider(
+	ctx context.Context,
+	logger *slog.Logger,
+	provider Provider,
+	d ...map[string]any,
+) (context.Context, error) {
+	if provider == nil {
+		return ctx, fmt.Errorf("no data provider available")
+	}
+	return AddDataToContextHelper(ctx, logger, provider, d...)
+}

--- a/platform/data/addDataToContext_test.go
+++ b/platform/data/addDataToContext_test.go
@@ -174,6 +174,36 @@ func TestAddDataToContextHelper(t *testing.T) {
 	})
 }
 
+// TestAddDataToContextFromProvider tests the convenience wrapper
+func TestAddDataToContextFromProvider(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.Default()
+
+	t.Run("nil provider returns error", func(t *testing.T) {
+		ctx := t.Context()
+		result, err := AddDataToContextFromProvider(ctx, logger, nil, map[string]any{"key": "value"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no data provider available")
+		assert.Equal(t, ctx, result)
+	})
+
+	t.Run("valid provider delegates to helper", func(t *testing.T) {
+		provider := NewContextProvider(constants.EvalData)
+		ctx := t.Context()
+
+		result, err := AddDataToContextFromProvider(ctx, logger, provider, map[string]any{"key": "value"})
+		require.NoError(t, err)
+		assert.NotEqual(t, ctx, result)
+
+		data := result.Value(constants.EvalData)
+		require.NotNil(t, data)
+		contextMap, ok := data.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "value", contextMap["key"])
+	})
+}
+
 // TestAddDataToContextWithErrorHandling tests error propagation in the AddDataToContextHelper
 func TestAddDataToContextWithErrorHandling(t *testing.T) {
 	t.Parallel()

--- a/platform/data/loadInputData.go
+++ b/platform/data/loadInputData.go
@@ -1,0 +1,34 @@
+package data
+
+import (
+	"context"
+	"log/slog"
+)
+
+// LoadInputData retrieves input data using the given data provider.
+// If the provider is nil, it returns an empty map. This function consolidates
+// the common data-loading logic used across all engine evaluators.
+func LoadInputData(
+	ctx context.Context,
+	logger *slog.Logger,
+	provider Provider,
+) (map[string]any, error) {
+	// If no data provider, return empty map
+	if provider == nil {
+		logger.WarnContext(ctx, "no data provider available, using empty data")
+		return make(map[string]any), nil
+	}
+
+	// Get input data from provider
+	inputData, err := provider.GetData(ctx)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to get input data from provider", "error", err)
+		return nil, err
+	}
+
+	if len(inputData) == 0 {
+		logger.WarnContext(ctx, "empty input data returned from provider")
+	}
+	logger.DebugContext(ctx, "input data loaded from provider", "inputData", inputData)
+	return inputData, nil
+}

--- a/platform/data/loadInputData.go
+++ b/platform/data/loadInputData.go
@@ -13,6 +13,10 @@ func LoadInputData(
 	logger *slog.Logger,
 	provider Provider,
 ) (map[string]any, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	// If no data provider, return empty map
 	if provider == nil {
 		logger.WarnContext(ctx, "no data provider available, using empty data")

--- a/platform/data/loadInputData_test.go
+++ b/platform/data/loadInputData_test.go
@@ -52,4 +52,22 @@ func TestLoadInputData(t *testing.T) {
 		assert.Empty(t, result)
 		provider.AssertExpectations(t)
 	})
+
+	t.Run("nil logger does not panic", func(t *testing.T) {
+		provider := new(MockProvider)
+		expected := map[string]any{"key": "value"}
+		provider.On("GetData", mock.Anything).Return(expected, nil)
+
+		result, err := LoadInputData(t.Context(), nil, provider)
+		require.NoError(t, err)
+		assert.Equal(t, expected, result)
+		provider.AssertExpectations(t)
+	})
+
+	t.Run("nil logger and nil provider does not panic", func(t *testing.T) {
+		result, err := LoadInputData(t.Context(), nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+		assert.NotNil(t, result)
+	})
 }

--- a/platform/data/loadInputData_test.go
+++ b/platform/data/loadInputData_test.go
@@ -1,0 +1,55 @@
+package data
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadInputData(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	t.Run("nil provider returns empty map", func(t *testing.T) {
+		result, err := LoadInputData(t.Context(), logger, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("provider returns data", func(t *testing.T) {
+		provider := new(MockProvider)
+		expected := map[string]any{"key": "value", "count": 42}
+		provider.On("GetData", mock.Anything).Return(expected, nil)
+
+		result, err := LoadInputData(t.Context(), logger, provider)
+		require.NoError(t, err)
+		assert.Equal(t, expected, result)
+		provider.AssertExpectations(t)
+	})
+
+	t.Run("provider returns error", func(t *testing.T) {
+		provider := new(MockProvider)
+		provider.On("GetData", mock.Anything).Return(nil, assert.AnError)
+
+		result, err := LoadInputData(t.Context(), logger, provider)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		provider.AssertExpectations(t)
+	})
+
+	t.Run("provider returns empty map", func(t *testing.T) {
+		provider := new(MockProvider)
+		provider.On("GetData", mock.Anything).Return(map[string]any{}, nil)
+
+		result, err := LoadInputData(t.Context(), logger, provider)
+		require.NoError(t, err)
+		assert.Empty(t, result)
+		provider.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
## Summary

The `loadInputData` and `AddDataToContext` methods were copy-pasted across all three engine evaluators (extism, risor, starlark) with identical logic. This PR consolidates them into shared helpers in `platform/data` and adds a small nil-safe `getDataProvider()` method on each evaluator. Pure refactor — no behaviour change.

## Changes

- `platform/data/loadInputData.go` *(new)* — `LoadInputData(ctx, logger, provider)` returns an empty map when the provider is nil, otherwise delegates to `provider.GetData` with the existing logging behaviour.
- `platform/data/addDataToContext.go` — adds `AddDataToContextFromProvider`, a nil-safe wrapper over the existing `AddDataToContextHelper`.
- Each evaluator (`engines/{extism,risor,starlark}/evaluator/evaluator.go`) gains a `getDataProvider()` method that returns the provider from the executable unit (or nil when the unit is nil), and delegates `loadInputData` / `AddDataToContext` to the new shared helpers.
- Tests for the new helpers in `platform/data/`.

## Test plan

- [x] `go test -race ./...` passes locally
- [x] CI green

The two commits are kept separate (`extract loadInputData` then `consolidate AddDataToContext`) so the diff is easier to follow; happy to squash on merge if preferred.