### PR TITLE
fix: stop mutating caller's *http.Request in RequestToMap

### DIFF
--- a/internal/helpers/requestToMap.go
+++ b/internal/helpers/requestToMap.go
@@ -91,7 +91,14 @@ func (h *httpRequestWrapper) toMap() map[string]any {
 	}
 }
 
-// RequestToMap converts an http.Request to a map[string]any using the httpRequest struct as an intermediary.
+// RequestToMap converts an http.Request to a map[string]any using the
+// httpRequest struct as an intermediary.
+//
+// RequestToMap reads r without mutating it: r.URL and r.Body are
+// observed but never reassigned. As a consequence, r.Body is consumed
+// like any io.Reader — after the call it will be at EOF. Callers that
+// need a re-readable body should clone it (e.g. via r.GetBody()) or
+// buffer it before passing the request in.
 func RequestToMap(r *http.Request) (map[string]any, error) {
 	// Transform http.Request to httpRequest struct
 	reqStruct, err := newHTTPRequestWrapper(r)

--- a/internal/helpers/requestToMap.go
+++ b/internal/helpers/requestToMap.go
@@ -21,20 +21,29 @@ type httpRequestWrapper struct {
 	QueryParams   map[string][]string
 }
 
+// resolveURL returns the request URL or a "/" sentinel when nil, so the
+// caller's r.URL is never mutated. It does not parse u itself; the
+// round-trip through url.Parse is preserved from the original
+// implementation and is tracked for removal under issue #100.
+func resolveURL(u *url.URL) (*url.URL, error) {
+	if u == nil {
+		return &url.URL{Path: "/"}, nil
+	}
+	if _, err := url.Parse(u.String()); err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	return u, nil
+}
+
 // newHTTPRequestWrapper converts an http.Request to an httpRequest struct.
 func newHTTPRequestWrapper(r *http.Request) (*httpRequestWrapper, error) {
 	if r == nil {
 		return nil, errors.New("request is nil")
 	}
 
-	// Compute URL locally so a nil r.URL doesn't get backfilled on the caller.
-	urlToUse := r.URL
-	if urlToUse == nil {
-		urlToUse = &url.URL{Path: "/"}
-	} else {
-		if _, err := url.Parse(urlToUse.String()); err != nil {
-			return nil, fmt.Errorf("invalid URL: %w", err)
-		}
+	urlToUse, err := resolveURL(r.URL)
+	if err != nil {
+		return nil, err
 	}
 
 	reqStruct := &httpRequestWrapper{

--- a/internal/helpers/requestToMap.go
+++ b/internal/helpers/requestToMap.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -28,20 +27,19 @@ func newHTTPRequestWrapper(r *http.Request) (*httpRequestWrapper, error) {
 		return nil, errors.New("request is nil")
 	}
 
-	// Ensure and validate the URL
-	if r.URL == nil {
-		// If URL is nil, provide a default one
-		r.URL = &url.URL{Path: "/"}
+	// Compute URL locally so a nil r.URL doesn't get backfilled on the caller.
+	urlToUse := r.URL
+	if urlToUse == nil {
+		urlToUse = &url.URL{Path: "/"}
 	} else {
-		// If URL is not nil, validate it
-		if _, err := url.Parse(r.URL.String()); err != nil {
+		if _, err := url.Parse(urlToUse.String()); err != nil {
 			return nil, fmt.Errorf("invalid URL: %w", err)
 		}
 	}
 
 	reqStruct := &httpRequestWrapper{
 		Method:        r.Method,
-		URL:           r.URL,
+		URL:           urlToUse,
 		Proto:         r.Proto,
 		ContentLength: r.ContentLength,
 		Host:          r.Host,
@@ -57,24 +55,18 @@ func newHTTPRequestWrapper(r *http.Request) (*httpRequestWrapper, error) {
 		}
 	}
 
-	// Read and set the body
+	// Read the body. The reader is consumed once — we don't restore it,
+	// since rewriting r.Body would mutate the caller's request.
 	if r.Body != nil {
 		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, err
 		}
 		reqStruct.Body = string(bodyBytes)
-
-		// Reset the body to allow further reads
-		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	}
 
-	// Copy query parameters if URL is present
-	if r.URL != nil {
-		query := r.URL.Query()
-		for k, v := range query {
-			reqStruct.QueryParams[k] = v
-		}
+	for k, v := range urlToUse.Query() {
+		reqStruct.QueryParams[k] = v
 	}
 
 	return reqStruct, nil

--- a/internal/helpers/requestToMap_test.go
+++ b/internal/helpers/requestToMap_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"bytes"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -222,5 +223,44 @@ func TestRequestToMap(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "/", result["URL_Path"])
 		require.Nil(t, req.URL, "caller's nil URL must stay nil")
+	})
+}
+
+// TestResolveURL covers the helper extracted from newHTTPRequestWrapper.
+func TestResolveURL(t *testing.T) {
+	t.Run("nil returns / sentinel", func(t *testing.T) {
+		got, err := resolveURL(nil)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, "/", got.Path)
+		require.Empty(t, got.Host)
+		require.Empty(t, got.Scheme)
+	})
+
+	t.Run("nil returns a fresh sentinel each call", func(t *testing.T) {
+		first, err := resolveURL(nil)
+		require.NoError(t, err)
+		second, err := resolveURL(nil)
+		require.NoError(t, err)
+		require.NotSame(t, first, second, "callers must not share a sentinel")
+	})
+
+	t.Run("non-nil returns same pointer", func(t *testing.T) {
+		input, err := url.Parse("http://example.com/path?q=1#frag")
+		require.NoError(t, err)
+
+		got, err := resolveURL(input)
+		require.NoError(t, err)
+		require.Same(t, input, got, "non-nil URL must be returned as-is")
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		input, err := url.Parse("http://example.com/path?q=1#frag")
+		require.NoError(t, err)
+		snapshot := *input
+
+		_, err = resolveURL(input)
+		require.NoError(t, err)
+		require.Equal(t, snapshot, *input, "fields of input URL must be unchanged")
 	})
 }

--- a/internal/helpers/requestToMap_test.go
+++ b/internal/helpers/requestToMap_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// trackingBody is a pointer-typed io.ReadCloser used in the
+// non-mutation regression test so require.Same can assert that
+// RequestToMap doesn't replace req.Body with a fresh wrapper.
+type trackingBody struct{ *bytes.Reader }
+
+func (*trackingBody) Close() error { return nil }
+
 // TestNewHTTPRequestWrapper tests the newHTTPRequestWrapper function.
 func TestNewHTTPRequestWrapper(t *testing.T) {
 	t.Run("with body", func(t *testing.T) {
@@ -187,19 +194,23 @@ func TestRequestToMap(t *testing.T) {
 		req, err := http.NewRequest(
 			http.MethodPost,
 			"http://localhost:8080/test?q=1",
-			bytes.NewBufferString(body),
+			nil,
 		)
 		require.NoError(t, err)
 
+		// Use a pointer-typed body wrapper so require.Same asserts
+		// pointer identity (io.NopCloser returns a value type).
+		bodyPtr := &trackingBody{Reader: bytes.NewReader([]byte(body))}
+		req.Body = bodyPtr
+
 		originalURL := req.URL
-		originalBody := req.Body
 
 		_, err = RequestToMap(req)
 		require.NoError(t, err)
 
-		require.Same(t, originalURL, req.URL, "URL pointer must be unchanged")
+		require.Same(t, originalURL, req.URL, "URL must not be replaced")
 		require.Equal(t, "/test", req.URL.Path, "URL path must be unchanged")
-		require.Equal(t, originalBody, req.Body, "Body reader must be unchanged")
+		require.Same(t, bodyPtr, req.Body, "Body must not be replaced")
 	})
 
 	t.Run("nil URL stays nil", func(t *testing.T) {

--- a/internal/helpers/requestToMap_test.go
+++ b/internal/helpers/requestToMap_test.go
@@ -199,7 +199,7 @@ func TestRequestToMap(t *testing.T) {
 
 		require.Same(t, originalURL, req.URL, "URL pointer must be unchanged")
 		require.Equal(t, "/test", req.URL.Path, "URL path must be unchanged")
-		require.True(t, originalBody == req.Body, "Body reader must be unchanged")
+		require.Equal(t, originalBody, req.Body, "Body reader must be unchanged")
 	})
 
 	t.Run("nil URL stays nil", func(t *testing.T) {

--- a/internal/helpers/requestToMap_test.go
+++ b/internal/helpers/requestToMap_test.go
@@ -181,4 +181,35 @@ func TestRequestToMap(t *testing.T) {
 		require.Equal(t, map[string][]string{}, result["Headers"])
 		require.Empty(t, result["Body"])
 	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		body := "test body"
+		req, err := http.NewRequest(
+			http.MethodPost,
+			"http://localhost:8080/test?q=1",
+			bytes.NewBufferString(body),
+		)
+		require.NoError(t, err)
+
+		originalURL := req.URL
+		originalBody := req.Body
+
+		_, err = RequestToMap(req)
+		require.NoError(t, err)
+
+		require.Same(t, originalURL, req.URL, "URL pointer must be unchanged")
+		require.Equal(t, "/test", req.URL.Path, "URL path must be unchanged")
+		require.True(t, originalBody == req.Body, "Body reader must be unchanged")
+	})
+
+	t.Run("nil URL stays nil", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+		require.NoError(t, err)
+		req.URL = nil
+
+		result, err := RequestToMap(req)
+		require.NoError(t, err)
+		require.Equal(t, "/", result["URL_Path"])
+		require.Nil(t, req.URL, "caller's nil URL must stay nil")
+	})
 }


### PR DESCRIPTION
## Summary

`internal/helpers/requestToMap.go` mutated the caller's `*http.Request` in two places:

- Backfilled `r.URL` when nil with a fabricated `&url.URL{Path: "/"}`.
- After draining `r.Body`, replaced it with a fresh `io.NopCloser(bytes.NewBuffer(...))`.

A script eval shouldn't be observable on the caller's request. The mutation became visible whenever the same request flowed through multiple evaluators, when middleware downstream of the eval inspected `r.URL` / `r.Body`, or when a caller drained the body upstream and expected it to *stay* drained.

This change moves the URL into a local sentinel and drops the body write-back. The `map[string]any` returned to scripts is unchanged — only the side effects on `r` go away.

Out of scope here: the dead `url.Parse(r.URL.String())` validation already flagged in #100; left as-is so the two PRs stay independent.

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [x] Two new regression subtests under `TestRequestToMap` assert pointer identity for `req.URL` and `req.Body` after the call, plus a "nil URL stays nil" case
- [ ] CI on the PR

Closes #92

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_