### PR TITLE
fix: cap HTTP-loaded script body size to prevent unbounded read DoS

### DIFF
--- a/platform/script/loader/errors.go
+++ b/platform/script/loader/errors.go
@@ -7,4 +7,5 @@ var (
 	ErrSchemeUnsupported  = errors.New("unsupported scheme")
 	ErrScriptNotAvailable = errors.New("script not available")
 	ErrInputEmpty         = errors.New("input is empty")
+	ErrScriptTooLarge     = errors.New("script exceeds maximum body size")
 )

--- a/platform/script/loader/fromHTTP.go
+++ b/platform/script/loader/fromHTTP.go
@@ -272,6 +272,15 @@ func (l *FromHTTP) GetReaderWithContext(ctx context.Context) (io.ReadCloser, err
 		)
 	}
 
+	return l.cappedBody(resp)
+}
+
+// cappedBody enforces HTTPOptions.MaxBodySize on the response. A zero
+// value falls back to DefaultMaxBodySize; a negative value returns the
+// body unwrapped. Otherwise the body is eagerly read into memory and
+// returned as a NopCloser; ErrScriptTooLarge is returned when it
+// exceeds the limit.
+func (l *FromHTTP) cappedBody(resp *http.Response) (io.ReadCloser, error) {
 	limit := l.options.MaxBodySize
 	if limit == 0 {
 		limit = DefaultMaxBodySize

--- a/platform/script/loader/fromHTTP.go
+++ b/platform/script/loader/fromHTTP.go
@@ -11,6 +11,7 @@
 package loader
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -23,6 +24,11 @@ import (
 	"github.com/robbyt/go-polyscript/internal/helpers"
 	"github.com/robbyt/go-polyscript/platform/script/loader/httpauth"
 )
+
+// DefaultMaxBodySize is the default cap on HTTP-loaded script bodies.
+// 10 MiB is large enough for any realistic script while keeping a single
+// rogue response from exhausting memory.
+const DefaultMaxBodySize int64 = 10 << 20
 
 // HTTPOptions contains configuration options for HTTP loader.
 // Use DefaultHTTPOptions() to get sensible defaults, then modify as needed.
@@ -51,6 +57,11 @@ type HTTPOptions struct {
 
 	// Headers for additional headers not related to authentication
 	Headers map[string]string
+
+	// MaxBodySize caps the response body in bytes. A zero value is treated
+	// as DefaultMaxBodySize; a negative value disables the cap. Bodies
+	// larger than the limit cause GetReader to return ErrScriptTooLarge.
+	MaxBodySize int64
 }
 
 // DefaultHTTPOptions returns default options for HTTP loader.
@@ -61,12 +72,14 @@ type HTTPOptions struct {
 // - InsecureSkipVerify: false (certificate validation enabled)
 // - Authenticator: NoAuth (no authentication)
 // - Headers: empty map (initialized, ready for values)
+// - MaxBodySize: DefaultMaxBodySize (10 MiB)
 func DefaultHTTPOptions() *HTTPOptions {
 	return &HTTPOptions{
 		Timeout:            30 * time.Second,
 		InsecureSkipVerify: false,
 		Authenticator:      httpauth.NewNoAuth(),
 		Headers:            make(map[string]string),
+		MaxBodySize:        DefaultMaxBodySize,
 	}
 }
 
@@ -102,6 +115,15 @@ func (o *HTTPOptions) WithNoAuth() *HTTPOptions {
 func (o *HTTPOptions) WithTimeout(timeout time.Duration) *HTTPOptions {
 	newOpts := *o
 	newOpts.Timeout = timeout
+	return &newOpts
+}
+
+// WithMaxBodySize returns a copy of options with the response body cap set.
+// Pass 0 to fall back to DefaultMaxBodySize, or a negative value to disable
+// the cap entirely.
+func (o *HTTPOptions) WithMaxBodySize(n int64) *HTTPOptions {
+	newOpts := *o
+	newOpts.MaxBodySize = n
 	return &newOpts
 }
 
@@ -249,7 +271,27 @@ func (l *FromHTTP) GetReaderWithContext(ctx context.Context) (io.ReadCloser, err
 		)
 	}
 
-	return resp.Body, nil
+	limit := l.options.MaxBodySize
+	if limit == 0 {
+		limit = DefaultMaxBodySize
+	}
+	if limit < 0 {
+		return resp.Body, nil
+	}
+
+	// Read up to limit+1 bytes so a body of exactly limit bytes passes
+	// while one byte more trips the overflow check.
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		slog.Default().Debug("Failed to close response body", "error", closeErr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+	if int64(len(buf)) > limit {
+		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrScriptTooLarge, l.url, limit)
+	}
+	return io.NopCloser(bytes.NewReader(buf)), nil
 }
 
 // GetSourceURL returns the source URL.

--- a/platform/script/loader/fromHTTP.go
+++ b/platform/script/loader/fromHTTP.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"time"
@@ -280,8 +281,15 @@ func (l *FromHTTP) GetReaderWithContext(ctx context.Context) (io.ReadCloser, err
 	}
 
 	// Read up to limit+1 bytes so a body of exactly limit bytes passes
-	// while one byte more trips the overflow check.
-	buf, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	// while one byte more trips the overflow check. Guard against
+	// MaxInt64 overflow: if limit is already at the int64 ceiling no
+	// realistic body can exceed it, so we read up to limit and the
+	// overflow branch is unreachable.
+	readLimit := limit
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, readLimit))
 	if closeErr := resp.Body.Close(); closeErr != nil {
 		slog.Default().Debug("Failed to close response body", "error", closeErr)
 	}

--- a/platform/script/loader/fromHTTP_test.go
+++ b/platform/script/loader/fromHTTP_test.go
@@ -664,3 +664,118 @@ func TestFromHTTP_GetSourceURL(t *testing.T) {
 func TestFromHTTP_ImplementsLoader(t *testing.T) {
 	var _ Loader = (*FromHTTP)(nil)
 }
+
+func TestFromHTTP_MaxBodySize(t *testing.T) {
+	t.Parallel()
+
+	// serveBody returns a test server that writes exactly size bytes.
+	// We intentionally don't assert on the Write error: when the loader
+	// rejects an oversize body it closes the connection mid-stream, which
+	// surfaces here as a broken-pipe error that isn't a test failure.
+	serveBody := func(size int) *httptest.Server {
+		body := make([]byte, size)
+		for i := range body {
+			body[i] = 'a'
+		}
+		return httptest.NewServer(
+			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+			}),
+		)
+	}
+
+	t.Run("body under limit succeeds", func(t *testing.T) {
+		server := serveBody(50)
+		defer server.Close()
+
+		opts := DefaultHTTPOptions().WithMaxBodySize(100)
+		loader, err := NewFromHTTPWithOptions(server.URL+"/s", opts)
+		require.NoError(t, err)
+
+		reader, err := loader.GetReader()
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("body exactly at limit succeeds", func(t *testing.T) {
+		server := serveBody(100)
+		defer server.Close()
+
+		opts := DefaultHTTPOptions().WithMaxBodySize(100)
+		loader, err := NewFromHTTPWithOptions(server.URL+"/s", opts)
+		require.NoError(t, err)
+
+		reader, err := loader.GetReader()
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("body over limit returns ErrScriptTooLarge", func(t *testing.T) {
+		server := serveBody(200)
+		defer server.Close()
+
+		opts := DefaultHTTPOptions().WithMaxBodySize(100)
+		loader, err := NewFromHTTPWithOptions(server.URL+"/s", opts)
+		require.NoError(t, err)
+
+		reader, err := loader.GetReader()
+		require.Error(t, err)
+		require.Nil(t, reader)
+		require.ErrorIs(t, err, ErrScriptTooLarge)
+	})
+
+	t.Run("MaxBodySize -1 disables cap", func(t *testing.T) {
+		// Serve well over the default 10 MiB cap.
+		size := int(DefaultMaxBodySize) + 1024
+		server := serveBody(size)
+		defer server.Close()
+
+		opts := DefaultHTTPOptions().WithMaxBodySize(-1)
+		loader, err := NewFromHTTPWithOptions(server.URL+"/s", opts)
+		require.NoError(t, err)
+
+		reader, err := loader.GetReader()
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		require.NoError(t, reader.Close())
+	})
+
+	t.Run("MaxBodySize 0 falls back to default", func(t *testing.T) {
+		// Bypass DefaultHTTPOptions to construct a zero-value field.
+		opts := &HTTPOptions{
+			Timeout:       30 * time.Second,
+			Authenticator: httpauth.NewNoAuth(),
+			Headers:       map[string]string{},
+			// MaxBodySize: 0 (zero value)
+		}
+		// Serve just over the default cap.
+		size := int(DefaultMaxBodySize) + 1
+		server := serveBody(size)
+		defer server.Close()
+
+		loader, err := NewFromHTTPWithOptions(server.URL+"/s", opts)
+		require.NoError(t, err)
+
+		reader, err := loader.GetReader()
+		require.Error(t, err)
+		require.Nil(t, reader)
+		require.ErrorIs(t, err, ErrScriptTooLarge)
+	})
+
+	t.Run("default options enforce 10 MiB cap", func(t *testing.T) {
+		size := int(DefaultMaxBodySize) + 1
+		server := serveBody(size)
+		defer server.Close()
+
+		loader, err := NewFromHTTP(server.URL + "/s")
+		require.NoError(t, err)
+
+		reader, err := loader.GetReader()
+		require.Error(t, err)
+		require.Nil(t, reader)
+		require.ErrorIs(t, err, ErrScriptTooLarge)
+	})
+}

--- a/platform/script/loader/fromHTTP_test.go
+++ b/platform/script/loader/fromHTTP_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// repeatingByte is an infinite io.Reader that emits a single byte
+// repeatedly. Used by TestFromHTTP_MaxBodySize's serveBody helper to
+// stream test response bodies via io.CopyN without allocating a full
+// buffer up front.
+type repeatingByte struct{ b byte }
+
+func (r repeatingByte) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
 
 func TestNewFromHTTP(t *testing.T) {
 	t.Parallel()
@@ -668,19 +682,20 @@ func TestFromHTTP_ImplementsLoader(t *testing.T) {
 func TestFromHTTP_MaxBodySize(t *testing.T) {
 	t.Parallel()
 
-	// serveBody returns a test server that writes exactly size bytes.
-	// Write errors are logged but not asserted: when the loader rejects
-	// an oversize body it closes the connection mid-stream, which
-	// surfaces here as a broken-pipe error that isn't a test failure.
-	serveBody := func(size int) *httptest.Server {
-		body := make([]byte, size)
-		for i := range body {
-			body[i] = 'a'
-		}
+	// serveBody returns a test server that streams exactly size bytes via
+	// io.CopyN over a small repeating buffer, so even multi-MiB cases
+	// don't allocate a full body up front.
+	//
+	// Write errors are logged on the caller's t (not asserted): when the
+	// loader rejects an oversize body it closes the connection
+	// mid-stream, surfacing as a broken-pipe error that isn't a test
+	// failure.
+	serveBody := func(t *testing.T, size int) *httptest.Server {
+		t.Helper()
 		return httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				if _, err := w.Write(body); err != nil {
+				if _, err := io.CopyN(w, repeatingByte{b: 'a'}, int64(size)); err != nil {
 					t.Logf("server write: %v", err)
 				}
 			}),
@@ -688,7 +703,7 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 	}
 
 	t.Run("body under limit succeeds", func(t *testing.T) {
-		server := serveBody(50)
+		server := serveBody(t, 50)
 		defer server.Close()
 
 		opts := DefaultHTTPOptions().WithMaxBodySize(100)
@@ -702,7 +717,7 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 	})
 
 	t.Run("body exactly at limit succeeds", func(t *testing.T) {
-		server := serveBody(100)
+		server := serveBody(t, 100)
 		defer server.Close()
 
 		opts := DefaultHTTPOptions().WithMaxBodySize(100)
@@ -716,7 +731,7 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 	})
 
 	t.Run("body over limit returns ErrScriptTooLarge", func(t *testing.T) {
-		server := serveBody(200)
+		server := serveBody(t, 200)
 		defer server.Close()
 
 		opts := DefaultHTTPOptions().WithMaxBodySize(100)
@@ -732,7 +747,7 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 	t.Run("MaxBodySize -1 disables cap", func(t *testing.T) {
 		// Serve well over the default 10 MiB cap.
 		size := int(DefaultMaxBodySize) + 1024
-		server := serveBody(size)
+		server := serveBody(t, size)
 		defer server.Close()
 
 		opts := DefaultHTTPOptions().WithMaxBodySize(-1)
@@ -755,7 +770,7 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 		}
 		// Serve just over the default cap.
 		size := int(DefaultMaxBodySize) + 1
-		server := serveBody(size)
+		server := serveBody(t, size)
 		defer server.Close()
 
 		loader, err := NewFromHTTPWithOptions(server.URL+"/s", opts)
@@ -769,7 +784,7 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 
 	t.Run("default options enforce 10 MiB cap", func(t *testing.T) {
 		size := int(DefaultMaxBodySize) + 1
-		server := serveBody(size)
+		server := serveBody(t, size)
 		defer server.Close()
 
 		loader, err := NewFromHTTP(server.URL + "/s")

--- a/platform/script/loader/fromHTTP_test.go
+++ b/platform/script/loader/fromHTTP_test.go
@@ -669,8 +669,8 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 	t.Parallel()
 
 	// serveBody returns a test server that writes exactly size bytes.
-	// We intentionally don't assert on the Write error: when the loader
-	// rejects an oversize body it closes the connection mid-stream, which
+	// Write errors are logged but not asserted: when the loader rejects
+	// an oversize body it closes the connection mid-stream, which
 	// surfaces here as a broken-pipe error that isn't a test failure.
 	serveBody := func(size int) *httptest.Server {
 		body := make([]byte, size)
@@ -680,7 +680,9 @@ func TestFromHTTP_MaxBodySize(t *testing.T) {
 		return httptest.NewServer(
 			http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(body)
+				if _, err := w.Write(body); err != nil {
+					t.Logf("server write: %v", err)
+				}
 			}),
 		)
 	}


### PR DESCRIPTION
## Summary

The HTTP loader returned `resp.Body` straight to compilers that `io.ReadAll` without limit, so a misbehaving server could exhaust process memory on any caller that loads scripts from arbitrary URLs.

- `HTTPOptions.MaxBodySize int64` with sentinel encoding: `0` falls back to `DefaultMaxBodySize` (10 MiB), negative disables the cap. `DefaultHTTPOptions()` populates the default so existing callers (only `inference.go` in production) inherit protection without code changes.
- New `WithMaxBodySize(int64)` option helper mirroring `WithBasicAuth` / `WithTimeout`.
- New `ErrScriptTooLarge` sentinel.
- `GetReaderWithContext` switches from streaming `resp.Body` to an eager read of `io.LimitReader(resp.Body, limit+1)`; the `+1` trick distinguishes exactly-at-limit (pass) from over-limit (fail). On overflow, returns `ErrScriptTooLarge` wrapping the URL and limit.
- Returns `io.NopCloser(bytes.NewReader(buf))` so downstream `Close()` is a no-op now that the loader owns the response body.

Eager buffering matches what every compiler already does (`io.ReadAll` under the hood) and the `Loader` interface doesn't promise streaming, so no caller is affected.

## Test plan

- [x] New `TestFromHTTP_MaxBodySize` covers six cases: under limit, exactly at limit, over limit (asserts `errors.Is(err, ErrScriptTooLarge)`), `WithMaxBodySize(-1)` disables the cap, zero-value field falls back to default, default options enforce the 10 MiB cap.
- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [ ] CI on the PR

Closes #98

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_