### PR TITLE
fix: unify nil-handler handling on slog.Default(); drop stale TODOs

### DIFF
--- a/engines/extism/compiler/compiler.go
+++ b/engines/extism/compiler/compiler.go
@@ -51,8 +51,6 @@ func (c *Compiler) String() string {
 }
 
 // Compile implements script.Compiler
-// TODO: Some error paths are difficult to test with the current design
-// Consider adding integration tests for hard-to-reach error cases.
 func (c *Compiler) Compile(scriptReader io.ReadCloser) (script.ExecutableContent, error) {
 	logger := c.logger.WithGroup("compile")
 

--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -130,8 +130,6 @@ func (be *Evaluator) exec(
 }
 
 // Eval implements evaluation.Evaluator
-// TODO: Some error paths in this method are hard to test with the current design
-// Consider adding more integration tests to cover these paths.
 func (be *Evaluator) Eval(ctx context.Context) (platform.EvaluatorResponse, error) {
 	logger := be.logger.WithGroup("Eval")
 	if be.execUnit == nil {

--- a/engines/extism/evaluator/response.go
+++ b/engines/extism/evaluator/response.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
+	"github.com/robbyt/go-polyscript/internal/helpers"
 	"github.com/robbyt/go-polyscript/platform/data"
 )
 
@@ -25,20 +25,14 @@ func newEvalResult(
 	execTime time.Duration,
 	scriptExeID string,
 ) *execResult {
-	if handler == nil {
-		defaultHandler := slog.NewTextHandler(os.Stdout, nil)
-		handler = defaultHandler.WithGroup("extism")
-		// Create a logger from the handler rather than using slog directly
-		defaultLogger := slog.New(handler)
-		defaultLogger.Warn("Handler is nil, using the default logger configuration.")
-	}
+	handler, logger := helpers.SetupLogger(handler, "extism", "execResult")
 
 	return &execResult{
 		value:       value,
 		execTime:    execTime,
 		scriptExeID: scriptExeID,
 		logHandler:  handler,
-		logger:      slog.New(handler.WithGroup("execResult")),
+		logger:      logger,
 	}
 }
 

--- a/engines/risor/evaluator/response.go
+++ b/engines/risor/evaluator/response.go
@@ -3,10 +3,10 @@ package evaluator
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	risorObject "github.com/deepnoodle-ai/risor/v2/pkg/object"
+	"github.com/robbyt/go-polyscript/internal/helpers"
 	"github.com/robbyt/go-polyscript/platform/data"
 )
 
@@ -26,20 +26,14 @@ func newEvalResult(
 	execTime time.Duration,
 	versionID string,
 ) *execResult {
-	if handler == nil {
-		defaultHandler := slog.NewTextHandler(os.Stdout, nil)
-		handler = defaultHandler.WithGroup("risor")
-		// Create a logger from the handler rather than using slog directly
-		defaultLogger := slog.New(handler)
-		defaultLogger.Warn("Handler is nil, using the default logger configuration.")
-	}
+	handler, logger := helpers.SetupLogger(handler, "risor", "execResult")
 
 	return &execResult{
 		Object:      obj,
 		execTime:    execTime,
 		scriptExeID: versionID,
 		logHandler:  handler,
-		logger:      slog.New(handler.WithGroup("execResult")),
+		logger:      logger,
 	}
 }
 

--- a/engines/starlark/evaluator/response.go
+++ b/engines/starlark/evaluator/response.go
@@ -3,10 +3,10 @@ package evaluator
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/robbyt/go-polyscript/engines/starlark/internal"
+	"github.com/robbyt/go-polyscript/internal/helpers"
 	"github.com/robbyt/go-polyscript/platform/data"
 	starlarkLib "go.starlark.net/starlark"
 )
@@ -26,13 +26,7 @@ func newEvalResult(
 	execTime time.Duration,
 	versionID string,
 ) *execResult {
-	if handler == nil {
-		defaultHandler := slog.NewTextHandler(os.Stdout, nil)
-		handler = defaultHandler.WithGroup("starlark")
-		// Create a logger from the handler rather than using slog directly
-		defaultLogger := slog.New(handler)
-		defaultLogger.Warn("Handler is nil, using the default logger configuration.")
-	}
+	handler, logger := helpers.SetupLogger(handler, "starlark", "execResult")
 
 	if obj == nil {
 		obj = starlarkLib.None
@@ -43,7 +37,7 @@ func newEvalResult(
 		execTime:    execTime,
 		scriptExeID: versionID,
 		logHandler:  handler,
-		logger:      slog.New(handler.WithGroup("execResult")),
+		logger:      logger,
 	}
 }
 

--- a/platform/data/addDataToContext.go
+++ b/platform/data/addDataToContext.go
@@ -26,7 +26,6 @@ func AddDataToContextHelper(
 	d ...map[string]any,
 ) (context.Context, error) {
 	if logger == nil {
-		// TODO: remove or use logger more effectively
 		logger = slog.Default()
 	}
 


### PR DESCRIPTION
## Summary

PR #105 (issue #85) made `SetupLogger` inherit from `slog.Default()` when given a nil handler, but three constructors still wrote a fresh `TextHandler` to `os.Stdout` in that case — the exact "library writes to stdout when nil-handler" pattern #99 was filed against:

- `engines/extism/evaluator/response.go` `newEvalResult`
- `engines/risor/evaluator/response.go` `newEvalResult`
- `engines/starlark/evaluator/response.go` `newEvalResult`

Each now delegates to `helpers.SetupLogger(handler, "<engine>", "execResult")`, so:
- nil handler → inherits from `slog.Default()` instead of writing to stdout
- the "Handler is nil, using the default logger configuration" warning is gone
- the `(engine, execResult)` group structure is preserved

Also drops three stale TODOs:

- `platform/data/addDataToContext.go` — the `slog.Default()` fallback is the right behavior post-#85; the TODO is a leftover.
- `engines/extism/compiler/compiler.go` `Compile()` — converted to **#108** with concrete branch list and an adapter-mock proposal.
- `engines/extism/evaluator/evaluator.go` `Eval()` — converted to **#109** with the equivalent treatment for `Eval`/`exec`/`execHelper`.

Coverage on the extism compiler/evaluator is ~93%; reaching the remaining branches needs an adapter-level mocking pass, tracked under #108/#109.

## Test plan

- [x] Existing `NilHandler` subtests in all three engines' `response_test.go` still pass (they assert `logHandler != nil` and `logger != nil`, which `SetupLogger` guarantees).
- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [x] CI on the PR

Closes #99

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_