### PR TITLE
fix: relax WithLogHandler(nil)/WithLogger(nil) to no-op across engines

### DIFF
--- a/engines/extism/compiler/options.go
+++ b/engines/extism/compiler/options.go
@@ -28,10 +28,13 @@ func WithEntryPoint(entryPoint string) FunctionalOption {
 // WithLogHandler creates an option to set the log handler for Extism compiler.
 // This is the preferred option for logging configuration as it provides
 // more flexibility through the slog.Handler interface.
+//
+// Passing a nil handler is a no-op equivalent to not calling the option:
+// the compiler inherits from slog.Default() via [helpers.SetupLogger].
 func WithLogHandler(handler slog.Handler) FunctionalOption {
 	return func(c *Compiler) error {
 		if handler == nil {
-			return fmt.Errorf("log handler cannot be nil")
+			return nil
 		}
 		c.logHandler = handler
 		// Clear logger if handler is explicitly set
@@ -43,10 +46,12 @@ func WithLogHandler(handler slog.Handler) FunctionalOption {
 // WithLogger creates an option to set a specific logger for Extism compiler.
 // This is less flexible than WithLogHandler but allows users to customize
 // their logging group configuration.
+//
+// Passing a nil logger is a no-op equivalent to not calling the option.
 func WithLogger(logger *slog.Logger) FunctionalOption {
 	return func(c *Compiler) error {
 		if logger == nil {
-			return fmt.Errorf("logger cannot be nil")
+			return nil
 		}
 		c.logger = logger
 		// Clear handler if logger is explicitly set

--- a/engines/extism/compiler/options_test.go
+++ b/engines/extism/compiler/options_test.go
@@ -85,15 +85,18 @@ func TestCompilerOptions_Options(t *testing.T) {
 			require.Contains(t, buf.String(), "test message", "log message should be captured")
 		})
 
-		// Error case
-		t.Run("nil handler", func(t *testing.T) {
+		t.Run("nil handler is no-op and preserves prior state", func(t *testing.T) {
+			var buf bytes.Buffer
+			real := slog.NewTextHandler(&buf, nil)
+
 			c := &Compiler{}
 			c.applyDefaults()
-			nilOpt := WithLogHandler(nil)
-			err := nilOpt(c)
+			require.NoError(t, WithLogHandler(real)(c))
 
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "log handler cannot be nil")
+			err := WithLogHandler(nil)(c)
+			require.NoError(t, err)
+			require.Equal(t, real, c.logHandler)
+			require.Nil(t, c.logger)
 		})
 	})
 
@@ -120,15 +123,19 @@ func TestCompilerOptions_Options(t *testing.T) {
 			require.Contains(t, buf.String(), "test message", "log message should be captured")
 		})
 
-		// Error case
-		t.Run("nil logger", func(t *testing.T) {
+		t.Run("nil logger is no-op and preserves prior state", func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, nil)
+			logger := slog.New(handler)
+
 			c := &Compiler{}
 			c.applyDefaults()
-			nilOpt := WithLogger(nil)
-			err := nilOpt(c)
+			require.NoError(t, WithLogger(logger)(c))
 
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "logger cannot be nil")
+			err := WithLogger(nil)(c)
+			require.NoError(t, err)
+			require.Equal(t, logger, c.logger)
+			require.Nil(t, c.logHandler)
 		})
 	})
 
@@ -719,14 +726,18 @@ func TestCompilerOptions(t *testing.T) {
 				require.Nil(t, c.logger) // Should clear Logger field
 			})
 
-			t.Run("nil handler", func(t *testing.T) {
+			t.Run("nil handler is no-op and preserves prior state", func(t *testing.T) {
+				var buf bytes.Buffer
+				real := slog.NewTextHandler(&buf, nil)
+
 				c := &Compiler{}
 				c.applyDefaults()
-				nilOpt := WithLogHandler(nil)
-				err := nilOpt(c)
+				require.NoError(t, WithLogHandler(real)(c))
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "log handler cannot be nil")
+				err := WithLogHandler(nil)(c)
+				require.NoError(t, err)
+				require.Equal(t, real, c.logHandler)
+				require.Nil(t, c.logger)
 			})
 		})
 
@@ -746,14 +757,15 @@ func TestCompilerOptions(t *testing.T) {
 				require.Nil(t, c.logHandler) // Should clear LogHandler field
 			})
 
-			t.Run("nil logger", func(t *testing.T) {
+			t.Run("nil logger is no-op and preserves prior state", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
-				nilOpt := WithLogger(nil)
-				err := nilOpt(c)
+				require.NoError(t, WithLogger(logger)(c))
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "logger cannot be nil")
+				err := WithLogger(nil)(c)
+				require.NoError(t, err)
+				require.Equal(t, logger, c.logger)
+				require.Nil(t, c.logHandler)
 			})
 		})
 	})

--- a/engines/risor/compiler/compiler_test.go
+++ b/engines/risor/compiler/compiler_test.go
@@ -372,16 +372,14 @@ func TestCompilerOptions(t *testing.T) {
 		require.NotNil(t, execContent)
 	})
 
-	t.Run("Option error handling", func(t *testing.T) {
-		// Test with nil logger
-		_, err := New(WithLogger(nil))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "logger cannot be nil")
+	t.Run("nil logger and handler options are no-ops", func(t *testing.T) {
+		comp, err := New(WithLogger(nil))
+		require.NoError(t, err)
+		require.NotNil(t, comp)
 
-		// Test with nil handler
-		_, err = New(WithLogHandler(nil))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "log handler cannot be nil")
+		comp, err = New(WithLogHandler(nil))
+		require.NoError(t, err)
+		require.NotNil(t, comp)
 	})
 }
 

--- a/engines/risor/compiler/options.go
+++ b/engines/risor/compiler/options.go
@@ -1,7 +1,6 @@
 package compiler
 
 import (
-	"fmt"
 	"log/slog"
 	"slices"
 
@@ -35,10 +34,13 @@ func WithCtxGlobal() FunctionalOption {
 // WithLogHandler creates an option to set the log handler for Risor compiler.
 // This is the preferred option for logging configuration as it provides
 // more flexibility through the slog.Handler interface.
+//
+// Passing a nil handler is a no-op equivalent to not calling the option:
+// the compiler inherits from slog.Default() via [helpers.SetupLogger].
 func WithLogHandler(handler slog.Handler) FunctionalOption {
 	return func(c *Compiler) error {
 		if handler == nil {
-			return fmt.Errorf("log handler cannot be nil")
+			return nil
 		}
 		c.logHandler = handler
 		// Clear logger if handler is explicitly set
@@ -50,10 +52,12 @@ func WithLogHandler(handler slog.Handler) FunctionalOption {
 // WithLogger creates an option to set a specific logger for Risor compiler.
 // This is less flexible than WithLogHandler but allows users to customize
 // their logging group configuration.
+//
+// Passing a nil logger is a no-op equivalent to not calling the option.
 func WithLogger(logger *slog.Logger) FunctionalOption {
 	return func(c *Compiler) error {
 		if logger == nil {
-			return fmt.Errorf("logger cannot be nil")
+			return nil
 		}
 		c.logger = logger
 		// Clear handler if logger is explicitly set

--- a/engines/risor/compiler/options_test.go
+++ b/engines/risor/compiler/options_test.go
@@ -189,14 +189,18 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.Nil(t, c.logger) // Should clear Logger field
 			})
 
-			t.Run("nil handler", func(t *testing.T) {
+			t.Run("nil handler is no-op and preserves prior state", func(t *testing.T) {
+				var buf bytes.Buffer
+				real := slog.NewTextHandler(&buf, nil)
+
 				c := &Compiler{}
 				c.applyDefaults()
-				nilOpt := WithLogHandler(nil)
-				err := nilOpt(c)
+				require.NoError(t, WithLogHandler(real)(c))
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "log handler cannot be nil")
+				err := WithLogHandler(nil)(c)
+				require.NoError(t, err)
+				require.Equal(t, real, c.logHandler)
+				require.Nil(t, c.logger)
 			})
 		})
 
@@ -216,14 +220,15 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.Nil(t, c.logHandler) // Should clear LogHandler field
 			})
 
-			t.Run("nil logger", func(t *testing.T) {
+			t.Run("nil logger is no-op and preserves prior state", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
-				nilOpt := WithLogger(nil)
-				err := nilOpt(c)
+				require.NoError(t, WithLogger(logger)(c))
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "logger cannot be nil")
+				err := WithLogger(nil)(c)
+				require.NoError(t, err)
+				require.Equal(t, logger, c.logger)
+				require.Nil(t, c.logHandler)
 			})
 		})
 	})

--- a/engines/starlark/compiler/compiler_test.go
+++ b/engines/starlark/compiler/compiler_test.go
@@ -375,16 +375,14 @@ func TestCompilerOptions(t *testing.T) {
 		require.NotNil(t, execContent)
 	})
 
-	t.Run("Option error handling", func(t *testing.T) {
-		// Test with nil logger
-		_, err := New(WithLogger(nil))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "logger cannot be nil")
+	t.Run("nil logger and handler options are no-ops", func(t *testing.T) {
+		comp, err := New(WithLogger(nil))
+		require.NoError(t, err)
+		require.NotNil(t, comp)
 
-		// Test with nil handler
-		_, err = New(WithLogHandler(nil))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "log handler cannot be nil")
+		comp, err = New(WithLogHandler(nil))
+		require.NoError(t, err)
+		require.NotNil(t, comp)
 	})
 }
 

--- a/engines/starlark/compiler/options.go
+++ b/engines/starlark/compiler/options.go
@@ -1,7 +1,6 @@
 package compiler
 
 import (
-	"fmt"
 	"log/slog"
 	"slices"
 
@@ -35,10 +34,13 @@ func WithCtxGlobal() FunctionalOption {
 // WithLogHandler creates an option to set the log handler for Starlark compiler.
 // This is the preferred option for logging configuration as it provides
 // more flexibility through the slog.Handler interface.
+//
+// Passing a nil handler is a no-op equivalent to not calling the option:
+// the compiler inherits from slog.Default() via [helpers.SetupLogger].
 func WithLogHandler(handler slog.Handler) FunctionalOption {
 	return func(c *Compiler) error {
 		if handler == nil {
-			return fmt.Errorf("log handler cannot be nil")
+			return nil
 		}
 		c.logHandler = handler
 		// Clear logger if handler is explicitly set
@@ -50,10 +52,12 @@ func WithLogHandler(handler slog.Handler) FunctionalOption {
 // WithLogger creates an option to set a specific logger for Starlark compiler.
 // This is less flexible than WithLogHandler but allows users to customize
 // their logging group configuration.
+//
+// Passing a nil logger is a no-op equivalent to not calling the option.
 func WithLogger(logger *slog.Logger) FunctionalOption {
 	return func(c *Compiler) error {
 		if logger == nil {
-			return fmt.Errorf("logger cannot be nil")
+			return nil
 		}
 		c.logger = logger
 		// Clear handler if logger is explicitly set

--- a/engines/starlark/compiler/options_test.go
+++ b/engines/starlark/compiler/options_test.go
@@ -189,14 +189,18 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.Nil(t, c.logger) // Should clear Logger field
 			})
 
-			t.Run("nil handler", func(t *testing.T) {
+			t.Run("nil handler is no-op and preserves prior state", func(t *testing.T) {
+				var buf bytes.Buffer
+				real := slog.NewTextHandler(&buf, nil)
+
 				c := &Compiler{}
 				c.applyDefaults()
-				nilOpt := WithLogHandler(nil)
-				err := nilOpt(c)
+				require.NoError(t, WithLogHandler(real)(c))
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "log handler cannot be nil")
+				err := WithLogHandler(nil)(c)
+				require.NoError(t, err)
+				require.Equal(t, real, c.logHandler)
+				require.Nil(t, c.logger)
 			})
 		})
 
@@ -216,14 +220,15 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.Nil(t, c.logHandler) // Should clear LogHandler field
 			})
 
-			t.Run("nil logger", func(t *testing.T) {
+			t.Run("nil logger is no-op and preserves prior state", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
-				nilOpt := WithLogger(nil)
-				err := nilOpt(c)
+				require.NoError(t, WithLogger(logger)(c))
 
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "logger cannot be nil")
+				err := WithLogger(nil)(c)
+				require.NoError(t, err)
+				require.Equal(t, logger, c.logger)
+				require.Nil(t, c.logHandler)
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

Relaxes `WithLogHandler(nil)` and `WithLogger(nil)` across the three engines' compiler packages so they're a no-op instead of returning an error. This makes them behave the way the rest of the package already does post-#85/#99 — every other nil-handler path routes through `helpers.SetupLogger`, which inherits from `slog.Default()`.

### Before

```go
func WithLogHandler(handler slog.Handler) FunctionalOption {
    return func(c *Compiler) error {
        if handler == nil {
            return fmt.Errorf("log handler cannot be nil")
        }
        // ...
    }
}
```

### After

```go
func WithLogHandler(handler slog.Handler) FunctionalOption {
    return func(c *Compiler) error {
        if handler == nil {
            return nil
        }
        // ...
    }
}
```

The "true no-op" detail (rather than "set field to nil") matters: `WithLogHandler(real)` followed by `WithLogHandler(nil)` now leaves the real handler in place, matching caller intuition.

### Idiomatic precedent

- Stdlib `slog.NewTextHandler(w, nil)` accepts nil opts and falls back to defaults.
- OpenTelemetry's `otelslog.WithLoggerProvider` defaults to the global provider when the option is omitted.
- The broader functional-options pattern treats `Option(nil)` as semantically equivalent to not calling the option at all — the absence already produces the default.

### Out of scope

The redundant `if cfg.handler != nil` guards in `polyscript.go:251/262/273` and `engines/{extism,risor,starlark}/new.go:72/85` exist solely to work around the now-removed nil-rejection. They become harmless once this lands. Cleanup is tracked under **#112** and depends on this PR.

### Files changed

- `engines/{extism,risor,starlark}/compiler/options.go` — relaxed both options + godoc
- `engines/{extism,risor,starlark}/compiler/options_test.go` — flipped "errors on nil" → "no-op on nil + prior state preserved"
- `engines/{risor,starlark}/compiler/compiler_test.go` — same flip for the higher-level "Option error handling" subtest
- `fmt` import dropped from risor and starlark `compiler/options.go` (no longer used; extism keeps it)

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [x] 8 updated tests assert no-op semantics + state preservation regression guard
- [ ] CI on the PR

Closes #111

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_