### PR TITLE
cleanup: drop redundant nil-handler guards; tighten WithLogHandler doc

### DIFF
--- a/engines/extism/new.go
+++ b/engines/extism/new.go
@@ -81,9 +81,9 @@ func FromExtismLoader(ldr loader.Loader, opts ...Option) (*evaluator.Evaluator, 
 
 	provider := resolveProvider(cfg)
 
-	compilerOpts := []compiler.FunctionalOption{compiler.WithEntryPoint(cfg.entryPoint)}
-	if cfg.handler != nil {
-		compilerOpts = append(compilerOpts, compiler.WithLogHandler(cfg.handler))
+	compilerOpts := []compiler.FunctionalOption{
+		compiler.WithEntryPoint(cfg.entryPoint),
+		compiler.WithLogHandler(cfg.handler),
 	}
 	comp, err := NewCompiler(compilerOpts...)
 	if err != nil {

--- a/engines/risor/new.go
+++ b/engines/risor/new.go
@@ -68,9 +68,9 @@ func FromRisorLoader(ldr loader.Loader, opts ...Option) (*evaluator.Evaluator, e
 
 	provider := resolveProvider(cfg)
 
-	compilerOpts := []compiler.FunctionalOption{compiler.WithCtxGlobal()}
-	if cfg.handler != nil {
-		compilerOpts = append(compilerOpts, compiler.WithLogHandler(cfg.handler))
+	compilerOpts := []compiler.FunctionalOption{
+		compiler.WithCtxGlobal(),
+		compiler.WithLogHandler(cfg.handler),
 	}
 	comp, err := NewCompiler(compilerOpts...)
 	if err != nil {

--- a/engines/starlark/new.go
+++ b/engines/starlark/new.go
@@ -68,9 +68,9 @@ func FromStarlarkLoader(ldr loader.Loader, opts ...Option) (*evaluator.Evaluator
 
 	provider := resolveProvider(cfg)
 
-	compilerOpts := []compiler.FunctionalOption{compiler.WithCtxGlobal()}
-	if cfg.handler != nil {
-		compilerOpts = append(compilerOpts, compiler.WithLogHandler(cfg.handler))
+	compilerOpts := []compiler.FunctionalOption{
+		compiler.WithCtxGlobal(),
+		compiler.WithLogHandler(cfg.handler),
 	}
 	comp, err := NewCompiler(compilerOpts...)
 	if err != nil {

--- a/polyscript.go
+++ b/polyscript.go
@@ -185,7 +185,8 @@ func WithStaticData[E Engine](data map[string]any) Option[E] {
 }
 
 // WithLogHandler sets the slog.Handler used for diagnostic logging by the
-// evaluator. If unset, the underlying engine picks a default.
+// evaluator. A nil handler is permitted and means "inherit from
+// slog.Default()" — equivalent to omitting the option.
 //
 // The type parameter is normally inferred from the surrounding [New] call.
 func WithLogHandler[E Engine](h slog.Handler) Option[E] {
@@ -247,10 +248,7 @@ func New[E Engine](src Source, opts ...Option[E]) (platform.Evaluator, error) {
 }
 
 func newRisor(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
-	var opts []risorMachine.Option
-	if cfg.handler != nil {
-		opts = append(opts, risorMachine.WithLogHandler(cfg.handler))
-	}
+	opts := []risorMachine.Option{risorMachine.WithLogHandler(cfg.handler)}
 	if cfg.staticData != nil {
 		opts = append(opts, risorMachine.WithStaticData(cfg.staticData))
 	}
@@ -258,10 +256,7 @@ func newRisor(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
 }
 
 func newStarlark(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
-	var opts []starlarkMachine.Option
-	if cfg.handler != nil {
-		opts = append(opts, starlarkMachine.WithLogHandler(cfg.handler))
-	}
+	opts := []starlarkMachine.Option{starlarkMachine.WithLogHandler(cfg.handler)}
 	if cfg.staticData != nil {
 		opts = append(opts, starlarkMachine.WithStaticData(cfg.staticData))
 	}
@@ -269,9 +264,9 @@ func newStarlark(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
 }
 
 func newExtism(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
-	opts := []extismMachine.Option{extismMachine.WithEntryPoint(cfg.entryPoint)}
-	if cfg.handler != nil {
-		opts = append(opts, extismMachine.WithLogHandler(cfg.handler))
+	opts := []extismMachine.Option{
+		extismMachine.WithEntryPoint(cfg.entryPoint),
+		extismMachine.WithLogHandler(cfg.handler),
 	}
 	if cfg.staticData != nil {
 		opts = append(opts, extismMachine.WithStaticData(cfg.staticData))


### PR DESCRIPTION
## Summary

Drops the six `cfg.handler != nil` guards that wrapped `WithLogHandler` calls in `polyscript.go` and `engines/{risor,starlark,extism}/new.go`. They existed solely to work around the pre-#111 nil-rejection — now that `WithLogHandler(nil)` is a true no-op across all three engines (PR #113), each guard produces identical behavior to an unconditional append.

Also tightens the top-level `polyscript.WithLogHandler` godoc to match the per-engine wording. The previous "If unset, the underlying engine picks a default" was vague about the nil case; the new wording matches `engines/{risor,starlark,extism}/options.go:19-21`.

### Diff shape

```go
// before
func newRisor(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
    var opts []risorMachine.Option
    if cfg.handler != nil {
        opts = append(opts, risorMachine.WithLogHandler(cfg.handler))
    }
    if cfg.staticData != nil {
        opts = append(opts, risorMachine.WithStaticData(cfg.staticData))
    }
    return risorMachine.FromRisorLoader(ldr, opts...)
}

// after
func newRisor(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
    opts := []risorMachine.Option{risorMachine.WithLogHandler(cfg.handler)}
    if cfg.staticData != nil {
        opts = append(opts, risorMachine.WithStaticData(cfg.staticData))
    }
    return risorMachine.FromRisorLoader(ldr, opts...)
}
```

### Out of scope (audited, no action)

- `helpers.SetupLogger` callers — 10 sites, all consistent `(engine, struct)` naming.
- Logger struct fields — `logHandler slog.Handler` + `logger *slog.Logger` everywhere.
- `slog.Default().Debug` cleanup-error logs in `platform/script/loader/{fromHTTP,fromDisk}.go` — these structs have no logger field; routing them through `SetupLogger` is a separate design call.
- No remaining logging-related TODOs in production code.

## Test plan

- [x] `git grep -n 'cfg.handler != nil' polyscript.go engines/{risor,starlark,extism}/new.go` returns zero hits
- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [x] Existing `polyscript_options_test.go:198-205` "WithLogHandler accepts nil" subtest stays green
- [ ] CI on the PR

Closes #112

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_