### PR TITLE
fix(extism): convert bare top-level json.Number in FixJSONNumberTypes

### DIFF
--- a/engines/extism/internal/jsonHelpers.go
+++ b/engines/extism/internal/jsonHelpers.go
@@ -48,6 +48,9 @@ func FixJSONNumberTypes(data any) any {
 		}
 		return v
 
+	case json.Number:
+		return convertJSONNumber(v)
+
 	default:
 		return data
 	}

--- a/engines/extism/internal/jsonHelpers_test.go
+++ b/engines/extism/internal/jsonHelpers_test.go
@@ -206,6 +206,24 @@ func TestFixJSONNumberTypes(t *testing.T) {
 		assert.IsType(t, float64(0), mapResult["huge"])
 	})
 
+	t.Run("converts top-level integer json.Number", func(t *testing.T) {
+		result := FixJSONNumberTypes(json.Number("42"))
+		assert.Equal(t, 42, result)
+		assert.IsType(t, int(0), result)
+	})
+
+	t.Run("converts top-level decimal json.Number", func(t *testing.T) {
+		result := FixJSONNumberTypes(json.Number("3.14"))
+		assert.InDelta(t, 3.14, result, 0.0001)
+		assert.IsType(t, float64(0), result)
+	})
+
+	t.Run("preserves invalid top-level json.Number", func(t *testing.T) {
+		result := FixJSONNumberTypes(json.Number("xyz"))
+		assert.Equal(t, json.Number("xyz"), result)
+		assert.IsType(t, json.Number(""), result)
+	})
+
 	t.Run("handles mixed types in map", func(t *testing.T) {
 		data := map[string]any{
 			"name":    "test",


### PR DESCRIPTION
## Summary

Fixes a bug where `FixJSONNumberTypes` left bare top-level `json.Number` values unconverted, so a WASM module returning a plain integer at the top level (e.g. `greet` exporting `42`) leaked `json.Number("42")` through to the caller's `result.Interface()` instead of arriving as `int(42)`.

The recursive walker at `engines/extism/internal/jsonHelpers.go:29-54` correctly converted `json.Number` values nested inside `map[string]any` or `[]any`, but the `default:` case returned bare values unchanged. The leaf rule wasn't applied at the root.

### Fix

One `case` branch ahead of `default:` that delegates to the existing `convertJSONNumber` helper (lines 13-24, same file):

```go
case json.Number:
    return convertJSONNumber(v)
```

No new helper. No new behavior beyond making the recursion's leaf rule apply at the root.

### Tests

Three subtests appended to `TestFixJSONNumberTypes`, mirroring the existing `TestConvertJSONNumber` cases:

- top-level integer `json.Number("42")` → `int(42)`
- top-level decimal `json.Number("3.14")` → `float64(3.14)`
- top-level invalid `json.Number("xyz")` → unchanged

The existing "handles primitive types" subtest (lines 20-24) already confirms `int`, `string`, and `bool` pass through unchanged — that's the regression guard against the fix accidentally widening the converter.

### Out of scope

- The exit-code-vs-output design question (#94) — separate issue.
- A WASM end-to-end regression test — would require new TinyGo source for a module that returns a top-level integer; disproportionate to a one-line helper fix.

## Test plan

- [x] `go test -race -count=1 ./engines/extism/internal/...` — green
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet ./...` — clean
- [ ] CI on the PR

Closes #95

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_