### PR TITLE
fix(risor,starlark): make WithGlobals additive; drop dead URL check

### DIFF
--- a/engines/risor/compiler/options.go
+++ b/engines/risor/compiler/options.go
@@ -11,10 +11,22 @@ import (
 // FunctionalOption is a function that configures a Compiler instance
 type FunctionalOption func(*Compiler) error
 
-// WithGlobals creates an option to set the globals for Risor scripts
+// WithGlobals creates an option to declare additional global identifiers
+// the Risor script may reference at evaluation time.
+//
+// WithGlobals is additive: each call appends to the compiler's existing
+// globals, deduplicating any names already present. Order-of-call no
+// longer matters when combined with [WithCtxGlobal]; both orderings
+// produce the same final set.
+//
+// A nil or empty slice is a no-op.
 func WithGlobals(globals []string) FunctionalOption {
 	return func(c *Compiler) error {
-		c.globals = globals
+		for _, g := range globals {
+			if !slices.Contains(c.globals, g) {
+				c.globals = append(c.globals, g)
+			}
+		}
 		return nil
 	}
 }

--- a/engines/risor/compiler/options_test.go
+++ b/engines/risor/compiler/options_test.go
@@ -27,17 +27,18 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.Equal(t, globals, c.globals)
 			})
 
-			t.Run("nil globals", func(t *testing.T) {
+			t.Run("nil globals is no-op", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
 				nilOpt := WithGlobals(nil)
 				err := nilOpt(c)
 
 				require.NoError(t, err)
-				require.Nil(t, c.globals)
+				require.NotNil(t, c.globals)
+				require.Empty(t, c.globals)
 			})
 
-			t.Run("empty globals", func(t *testing.T) {
+			t.Run("empty globals is no-op", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
 				emptyOpt := WithGlobals([]string{})
@@ -46,6 +47,41 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, c.globals)
 				require.Empty(t, c.globals)
+			})
+
+			t.Run("order-independent with WithCtxGlobal", func(t *testing.T) {
+				// WithCtxGlobal then WithGlobals
+				c1 := &Compiler{}
+				c1.applyDefaults()
+				require.NoError(t, WithCtxGlobal()(c1))
+				require.NoError(t, WithGlobals([]string{"x"})(c1))
+
+				// WithGlobals then WithCtxGlobal
+				c2 := &Compiler{}
+				c2.applyDefaults()
+				require.NoError(t, WithGlobals([]string{"x"})(c2))
+				require.NoError(t, WithCtxGlobal()(c2))
+
+				require.ElementsMatch(t, c1.globals, c2.globals)
+				require.ElementsMatch(t, []string{constants.Ctx, "x"}, c1.globals)
+			})
+
+			t.Run("dedupes within a single call", func(t *testing.T) {
+				c := &Compiler{}
+				c.applyDefaults()
+				err := WithGlobals([]string{"a", "b", "a"})(c)
+
+				require.NoError(t, err)
+				require.Equal(t, []string{"a", "b"}, c.globals)
+			})
+
+			t.Run("dedupes across multiple calls", func(t *testing.T) {
+				c := &Compiler{}
+				c.applyDefaults()
+				require.NoError(t, WithGlobals([]string{"a", "b"})(c))
+				require.NoError(t, WithGlobals([]string{"b", "c"})(c))
+
+				require.Equal(t, []string{"a", "b", "c"}, c.globals)
 			})
 		})
 

--- a/engines/starlark/compiler/options.go
+++ b/engines/starlark/compiler/options.go
@@ -11,10 +11,22 @@ import (
 // FunctionalOption is a function that configures a Compiler instance
 type FunctionalOption func(*Compiler) error
 
-// WithGlobals creates an option to set the globals for Starlark scripts
+// WithGlobals creates an option to declare additional global identifiers
+// the Starlark script may reference at evaluation time.
+//
+// WithGlobals is additive: each call appends to the compiler's existing
+// globals, deduplicating any names already present. Order-of-call no
+// longer matters when combined with [WithCtxGlobal]; both orderings
+// produce the same final set.
+//
+// A nil or empty slice is a no-op.
 func WithGlobals(globals []string) FunctionalOption {
 	return func(c *Compiler) error {
-		c.globals = globals
+		for _, g := range globals {
+			if !slices.Contains(c.globals, g) {
+				c.globals = append(c.globals, g)
+			}
+		}
 		return nil
 	}
 }

--- a/engines/starlark/compiler/options_test.go
+++ b/engines/starlark/compiler/options_test.go
@@ -27,17 +27,18 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.Equal(t, globals, c.globals)
 			})
 
-			t.Run("nil globals", func(t *testing.T) {
+			t.Run("nil globals is no-op", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
 				nilOpt := WithGlobals(nil)
 				err := nilOpt(c)
 
 				require.NoError(t, err)
-				require.Nil(t, c.globals)
+				require.NotNil(t, c.globals)
+				require.Empty(t, c.globals)
 			})
 
-			t.Run("empty globals", func(t *testing.T) {
+			t.Run("empty globals is no-op", func(t *testing.T) {
 				c := &Compiler{}
 				c.applyDefaults()
 				emptyOpt := WithGlobals([]string{})
@@ -46,6 +47,41 @@ func TestCompilerOptionsDetailed(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, c.globals)
 				require.Empty(t, c.globals)
+			})
+
+			t.Run("order-independent with WithCtxGlobal", func(t *testing.T) {
+				// WithCtxGlobal then WithGlobals
+				c1 := &Compiler{}
+				c1.applyDefaults()
+				require.NoError(t, WithCtxGlobal()(c1))
+				require.NoError(t, WithGlobals([]string{"x"})(c1))
+
+				// WithGlobals then WithCtxGlobal
+				c2 := &Compiler{}
+				c2.applyDefaults()
+				require.NoError(t, WithGlobals([]string{"x"})(c2))
+				require.NoError(t, WithCtxGlobal()(c2))
+
+				require.ElementsMatch(t, c1.globals, c2.globals)
+				require.ElementsMatch(t, []string{constants.Ctx, "x"}, c1.globals)
+			})
+
+			t.Run("dedupes within a single call", func(t *testing.T) {
+				c := &Compiler{}
+				c.applyDefaults()
+				err := WithGlobals([]string{"a", "b", "a"})(c)
+
+				require.NoError(t, err)
+				require.Equal(t, []string{"a", "b"}, c.globals)
+			})
+
+			t.Run("dedupes across multiple calls", func(t *testing.T) {
+				c := &Compiler{}
+				c.applyDefaults()
+				require.NoError(t, WithGlobals([]string{"a", "b"})(c))
+				require.NoError(t, WithGlobals([]string{"b", "c"})(c))
+
+				require.Equal(t, []string{"a", "b", "c"}, c.globals)
 			})
 		})
 

--- a/internal/helpers/requestToMap.go
+++ b/internal/helpers/requestToMap.go
@@ -22,17 +22,12 @@ type httpRequestWrapper struct {
 }
 
 // resolveURL returns the request URL or a "/" sentinel when nil, so the
-// caller's r.URL is never mutated. It does not parse u itself; the
-// round-trip through url.Parse is preserved from the original
-// implementation and is tracked for removal under issue #100.
-func resolveURL(u *url.URL) (*url.URL, error) {
+// caller's r.URL is never mutated.
+func resolveURL(u *url.URL) *url.URL {
 	if u == nil {
-		return &url.URL{Path: "/"}, nil
+		return &url.URL{Path: "/"}
 	}
-	if _, err := url.Parse(u.String()); err != nil {
-		return nil, fmt.Errorf("invalid URL: %w", err)
-	}
-	return u, nil
+	return u
 }
 
 // newHTTPRequestWrapper converts an http.Request to an httpRequest struct.
@@ -41,10 +36,7 @@ func newHTTPRequestWrapper(r *http.Request) (*httpRequestWrapper, error) {
 		return nil, errors.New("request is nil")
 	}
 
-	urlToUse, err := resolveURL(r.URL)
-	if err != nil {
-		return nil, err
-	}
+	urlToUse := resolveURL(r.URL)
 
 	reqStruct := &httpRequestWrapper{
 		Method:        r.Method,

--- a/internal/helpers/requestToMap_test.go
+++ b/internal/helpers/requestToMap_test.go
@@ -229,8 +229,7 @@ func TestRequestToMap(t *testing.T) {
 // TestResolveURL covers the helper extracted from newHTTPRequestWrapper.
 func TestResolveURL(t *testing.T) {
 	t.Run("nil returns / sentinel", func(t *testing.T) {
-		got, err := resolveURL(nil)
-		require.NoError(t, err)
+		got := resolveURL(nil)
 		require.NotNil(t, got)
 		require.Equal(t, "/", got.Path)
 		require.Empty(t, got.Host)
@@ -238,10 +237,8 @@ func TestResolveURL(t *testing.T) {
 	})
 
 	t.Run("nil returns a fresh sentinel each call", func(t *testing.T) {
-		first, err := resolveURL(nil)
-		require.NoError(t, err)
-		second, err := resolveURL(nil)
-		require.NoError(t, err)
+		first := resolveURL(nil)
+		second := resolveURL(nil)
 		require.NotSame(t, first, second, "callers must not share a sentinel")
 	})
 
@@ -249,8 +246,7 @@ func TestResolveURL(t *testing.T) {
 		input, err := url.Parse("http://example.com/path?q=1#frag")
 		require.NoError(t, err)
 
-		got, err := resolveURL(input)
-		require.NoError(t, err)
+		got := resolveURL(input)
 		require.Same(t, input, got, "non-nil URL must be returned as-is")
 	})
 
@@ -259,8 +255,7 @@ func TestResolveURL(t *testing.T) {
 		require.NoError(t, err)
 		snapshot := *input
 
-		_, err = resolveURL(input)
-		require.NoError(t, err)
+		_ = resolveURL(input)
 		require.Equal(t, snapshot, *input, "fields of input URL must be unchanged")
 	})
 }


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled into issue #100.

### Part 1 — `WithGlobals` order-dependence (Risor + Starlark)

Both engines had identical buggy code: `WithCtxGlobal()` was additive (appended `ctx` if missing), but `WithGlobals()` was destructive (overwrote). So option order mattered:

```go
New(WithGlobals(["x"]), WithCtxGlobal())  // → ["x", "ctx"]   works
New(WithCtxGlobal(), WithGlobals(["x"]))  // → ["x"]          silently drops ctx
```

Functional options should be order-independent. `WithGlobals` is now additive (append + dedupe), so both orderings produce the same final set.

The issue body suggested a separate `WithGlobalsExact` for the "replace-all" semantic — not added preemptively (per the user's "backwards compat is not a goal" directive). Callers needing replace-all can construct the slice once and call `WithGlobals` once.

### Part 2 — dead URL check in `resolveURL`

`internal/helpers/requestToMap.go` already carried the comment "tracked for removal under issue #100" on the dead `url.Parse(u.String())` roundtrip. `String()` is the inverse of `Parse` for any `*url.URL` Go produced — the err path is unreachable.

Removed the check. With no error path left, the unexported helper's signature simplifies from `(*url.URL, error)` to `*url.URL`. The one caller (`newHTTPRequestWrapper`) and four `resolveURL` test subtests updated to drop the `, err` return. `fmt` import stays — `RequestToMap` itself still wraps errors.

### Tests

For `WithGlobals` (mirrored across both engines):

- `nil globals` / `empty globals` subtests now assert no-op semantics (`NotNil` + `Empty`) instead of the prior `require.Nil`. `applyDefaults` initializes `c.globals = []string{}`, and additive nil/empty leaves it untouched.
- Three new subtests lock the new contract:
  - **order-independent with `WithCtxGlobal`** — both orderings yield the same set
  - **dedupes within a single call** — `["a","b","a"]` → `["a","b"]`
  - **dedupes across multiple calls** — `["a","b"]` then `["b","c"]` → `["a","b","c"]`

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [x] `git grep -n 'WithGlobalsExact'` returns zero hits (we deliberately did not add it)
- [ ] CI on the PR

Closes #100

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_