### PR TITLE
test(extism): cover Eval loadInputData and ConvertToExtismFormat errors

### DIFF
--- a/engines/extism/evaluator/evaluator_test.go
+++ b/engines/extism/evaluator/evaluator_test.go
@@ -66,6 +66,23 @@ func (m *mockErrProvider) AddDataToContext(
 	return ctx, m.err
 }
 
+// mockMapProvider returns a fixed data map without erroring. Tests use this
+// to control the bytes that flow into internal.ConvertToExtismFormat.
+type mockMapProvider struct {
+	data map[string]any
+}
+
+func (m *mockMapProvider) GetData(ctx context.Context) (map[string]any, error) {
+	return m.data, nil
+}
+
+func (m *mockMapProvider) AddDataToContext(
+	ctx context.Context,
+	data ...map[string]any,
+) (context.Context, error) {
+	return ctx, nil
+}
+
 // mockPluginInstance is a mock implementation of the adapters.PluginInstance interface
 type mockPluginInstance struct {
 	exitCode   uint32
@@ -461,6 +478,51 @@ func TestEvaluator_Evaluate(t *testing.T) {
 			_, err := evaluator.Eval(ctx)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "failed to create plugin instance")
+		})
+
+		// Eval should wrap the data-provider's error when loadInputData fails,
+		// without ever reaching plugin.Instance.
+		t.Run("load input data error", func(t *testing.T) {
+			handler := slog.NewTextHandler(os.Stdout, nil)
+			mockPlugin := new(MockCompiledPlugin)
+			content := createMockExecutable(mockPlugin, "main")
+
+			exe := &script.ExecutableUnit{
+				ID:           "test-load-input-error",
+				DataProvider: &mockErrProvider{err: errors.New("provider boom")},
+				Content:      content,
+			}
+
+			evaluator := New(handler, exe)
+			_, err := evaluator.Eval(t.Context())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to get input data")
+			assert.Contains(t, err.Error(), "provider boom")
+			mockPlugin.AssertNotCalled(t, "Instance", mock.Anything, mock.Anything)
+		})
+
+		// Eval should wrap json.Marshal errors from internal.ConvertToExtismFormat
+		// without reaching plugin.Instance. A chan value is not JSON-marshalable.
+		t.Run("convert to extism format error", func(t *testing.T) {
+			handler := slog.NewTextHandler(os.Stdout, nil)
+			mockPlugin := new(MockCompiledPlugin)
+			content := createMockExecutable(mockPlugin, "main")
+
+			exe := &script.ExecutableUnit{
+				ID: "test-convert-format-error",
+				DataProvider: &mockMapProvider{data: map[string]any{
+					"bad": make(chan int),
+				}},
+				Content: content,
+			}
+
+			evaluator := New(handler, exe)
+			_, err := evaluator.Eval(t.Context())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "failed to marshal input data")
+			mockPlugin.AssertNotCalled(t, "Instance", mock.Anything, mock.Anything)
 		})
 	})
 


### PR DESCRIPTION
## Summary

Issue #109 listed 6 hard-to-reach error branches in `engines/extism/evaluator/evaluator.go`. Auditing the existing test suite found that **4 of the 6 were already covered**:

| Issue's proposed subtest | Already covered by |
|---|---|
| `plugin instance error` | `TestEvaluator_Evaluate/error_cases/error creating plugin instance` (L443) |
| `call with context cancellation` | `TestEvaluator_Evaluate/error_cases/context cancellation` (L366) + `metadata_tests/exec helper/context cancellation` (L553) |
| `call with context plain error` | `metadata_tests/exec helper/execution error` (L540) |
| `non-JSON output falls back to string` | `success_cases/successful execution with string output` (L185) — passes plain text bytes, asserts string fallback |

The remaining two branches in `Eval()` itself were genuinely uncovered. This PR adds two subtests under `TestEvaluator_Evaluate/error_cases`:

### 1. `load input data error` — covers `evaluator.go:172-175`

Wires the existing `mockErrProvider` into `ExecutableUnit.DataProvider`. Verifies `Eval` returns the wrapped `"failed to get input data"` error and never reaches `plugin.Instance`.

### 2. `convert to extism format error` — covers `evaluator.go:178-181`

Adds a tiny `mockMapProvider` helper next to `mockErrProvider`; populates it with `chan int` (not JSON-marshalable). Verifies `Eval` returns the wrapped `"failed to marshal input data"` error and never reaches `plugin.Instance`.

### Scaffolding

`mockMapProvider` is the only new scaffolding — `MockCompiledPlugin`, `mockPluginInstance`, `mockErrProvider`, and `createMockExecutable()` all existed.

### Out of scope

The `instance.Close(ctx)` failure paths (L96-98 in compiler, L118-122 in evaluator) — the issue body notes these are "logged-only, doesn't propagate, so coverage value is low." Left intentionally untested.

The exit-code-vs-output design question (#94) — separate issue.

## Test plan

- [x] `go test -race -count=1 ./engines/extism/evaluator/...` — green; 2 new subtests visible
- [x] Coverage: extism/evaluator went from ~93% to **95.5%**
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] CI on the PR

Closes #109

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_