### PR TITLE
fix(extism): include WASM output in non-zero-exit-code error

### DIFF
--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -57,6 +57,28 @@ func (be *Evaluator) loadInputData(ctx context.Context) (map[string]any, error) 
 	return data.LoadInputData(ctx, be.logger.WithGroup("loadInputData"), be.getDataProvider())
 }
 
+// exitOutputMaxBytes caps the output snippet included in non-zero-exit
+// error messages so a multi-megabyte plugin payload can't blow up logs.
+const exitOutputMaxBytes = 1024
+
+// formatExitOutput returns a parenthesized " (output: %q)" suffix for
+// inclusion in non-zero-exit-code errors. Returns "" when output is empty,
+// so callers don't get a noisy '(output: "")' tail. Long outputs are
+// truncated to exitOutputMaxBytes; the original byte length is surfaced
+// so callers can tell something was elided.
+func formatExitOutput(output []byte) string {
+	if len(output) == 0 {
+		return ""
+	}
+	if len(output) <= exitOutputMaxBytes {
+		return fmt.Sprintf(" (output: %q)", output)
+	}
+	return fmt.Sprintf(
+		" (output: %q, truncated from %d bytes)",
+		output[:exitOutputMaxBytes], len(output),
+	)
+}
+
 // execHelper is a utility function to handle common execution logic
 // Extracted to make unit testing easier
 func execHelper(
@@ -77,8 +99,10 @@ func execHelper(
 		return nil, execTime, fmt.Errorf("execution failed: %w", err)
 	}
 	if exit != 0 {
-		// TODO should we return the output in this case?
-		return nil, execTime, fmt.Errorf("function returned non-zero exit code: %d", exit)
+		return nil, execTime, fmt.Errorf(
+			"function returned non-zero exit code: %d%s",
+			exit, formatExitOutput(output),
+		)
 	}
 
 	// Try to parse output as JSON with number handling

--- a/engines/extism/evaluator/evaluator_test.go
+++ b/engines/extism/evaluator/evaluator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -620,12 +621,14 @@ func TestEvaluator_Evaluate(t *testing.T) {
 					errExcludes: []string{"(output:"},
 				},
 				{
+					// Sized as a multiple of exitOutputMaxBytes so the
+					// truncation branch keeps firing if the cap is raised.
 					name: "non-zero exit code with truncated output",
 					setup: func() (*mockPluginInstance, context.Context, context.CancelFunc) {
 						ctx, cancel := context.WithCancel(t.Context())
 						return &mockPluginInstance{
 							exitCode: 2,
-							output:   bytes.Repeat([]byte("X"), 2048),
+							output:   bytes.Repeat([]byte("X"), exitOutputMaxBytes*2),
 						}, ctx, cancel
 					},
 					entryPoint: "main",
@@ -633,7 +636,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 					wantErr:    true,
 					errContainsAll: []string{
 						"non-zero exit code: 2",
-						"truncated from 2048 bytes",
+						fmt.Sprintf("truncated from %d bytes", exitOutputMaxBytes*2),
 					},
 				},
 				{
@@ -858,7 +861,7 @@ func TestFormatExitOutput(t *testing.T) {
 		payload := bytes.Repeat([]byte("a"), exitOutputMaxBytes+5)
 		got := formatExitOutput(payload)
 		assert.Contains(t, got, "truncated from")
-		assert.Contains(t, got, "1029 bytes")
+		assert.Contains(t, got, fmt.Sprintf("%d bytes", len(payload)))
 	})
 
 	t.Run("control characters are escaped via %q", func(t *testing.T) {

--- a/engines/extism/evaluator/evaluator_test.go
+++ b/engines/extism/evaluator/evaluator_test.go
@@ -839,8 +839,8 @@ func TestFormatExitOutput(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty output produces no suffix", func(t *testing.T) {
-		assert.Equal(t, "", formatExitOutput(nil))
-		assert.Equal(t, "", formatExitOutput([]byte{}))
+		assert.Empty(t, formatExitOutput(nil))
+		assert.Empty(t, formatExitOutput([]byte{}))
 	})
 
 	t.Run("short output is quoted in full", func(t *testing.T) {

--- a/engines/extism/evaluator/evaluator_test.go
+++ b/engines/extism/evaluator/evaluator_test.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -454,6 +455,9 @@ func TestEvaluator_Evaluate(t *testing.T) {
 			_, err := evaluator.Eval(ctx)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "non-zero exit code")
+			// Output bytes should now be surfaced in the error so the host
+			// can diagnose the misbehaving plugin (issue #94).
+			assert.Contains(t, err.Error(), "something went wrong")
 		})
 
 		// Test error creating plugin instance
@@ -564,12 +568,13 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		// Test the exec helper function
 		t.Run("exec helper", func(t *testing.T) {
 			tests := []struct {
-				name        string
-				setup       func() (*mockPluginInstance, context.Context, context.CancelFunc)
-				entryPoint  string
-				input       []byte
-				wantErr     bool
-				errContains string
+				name           string
+				setup          func() (*mockPluginInstance, context.Context, context.CancelFunc)
+				entryPoint     string
+				input          []byte
+				wantErr        bool
+				errContainsAll []string
+				errExcludes    []string
 			}{
 				{
 					name: "successful execution",
@@ -593,10 +598,43 @@ func TestEvaluator_Evaluate(t *testing.T) {
 							output:   []byte(`{"error": "something went wrong"}`),
 						}, ctx, cancel
 					},
-					entryPoint:  "main",
-					input:       []byte(`{"key":"value"}`),
-					wantErr:     true,
-					errContains: "non-zero exit code",
+					entryPoint:     "main",
+					input:          []byte(`{"key":"value"}`),
+					wantErr:        true,
+					errContainsAll: []string{"non-zero exit code", "something went wrong"},
+				},
+				{
+					name: "non-zero exit code with empty output",
+					setup: func() (*mockPluginInstance, context.Context, context.CancelFunc) {
+						ctx, cancel := context.WithCancel(t.Context())
+						return &mockPluginInstance{
+							exitCode: 1,
+							output:   nil,
+						}, ctx, cancel
+					},
+					entryPoint:     "main",
+					input:          []byte(`{"key":"value"}`),
+					wantErr:        true,
+					errContainsAll: []string{"non-zero exit code: 1"},
+					// Empty output must not produce a noisy '(output: "")' tail.
+					errExcludes: []string{"(output:"},
+				},
+				{
+					name: "non-zero exit code with truncated output",
+					setup: func() (*mockPluginInstance, context.Context, context.CancelFunc) {
+						ctx, cancel := context.WithCancel(t.Context())
+						return &mockPluginInstance{
+							exitCode: 2,
+							output:   bytes.Repeat([]byte("X"), 2048),
+						}, ctx, cancel
+					},
+					entryPoint: "main",
+					input:      []byte(`{"key":"value"}`),
+					wantErr:    true,
+					errContainsAll: []string{
+						"non-zero exit code: 2",
+						"truncated from 2048 bytes",
+					},
 				},
 				{
 					name: "execution error",
@@ -606,10 +644,10 @@ func TestEvaluator_Evaluate(t *testing.T) {
 							callErr: errors.New("execution failed"),
 						}, ctx, cancel
 					},
-					entryPoint:  "main",
-					input:       []byte(`{"key":"value"}`),
-					wantErr:     true,
-					errContains: "execution failed",
+					entryPoint:     "main",
+					input:          []byte(`{"key":"value"}`),
+					wantErr:        true,
+					errContainsAll: []string{"execution failed"},
 				},
 				{
 					name: "context cancellation",
@@ -621,10 +659,10 @@ func TestEvaluator_Evaluate(t *testing.T) {
 						}
 						return mock, ctx, cancel
 					},
-					entryPoint:  "main",
-					input:       []byte(`{"key":"value"}`),
-					wantErr:     true,
-					errContains: "cancelled",
+					entryPoint:     "main",
+					input:          []byte(`{"key":"value"}`),
+					wantErr:        true,
+					errContainsAll: []string{"cancelled"},
 				},
 			}
 
@@ -651,8 +689,11 @@ func TestEvaluator_Evaluate(t *testing.T) {
 
 					if tt.wantErr {
 						require.Error(t, err)
-						if tt.errContains != "" {
-							assert.Contains(t, err.Error(), tt.errContains)
+						for _, s := range tt.errContainsAll {
+							assert.Contains(t, err.Error(), s)
+						}
+						for _, s := range tt.errExcludes {
+							assert.NotContains(t, err.Error(), s)
 						}
 					} else {
 						require.NoError(t, err)
@@ -790,4 +831,40 @@ func TestEvaluator_AddDataToContext(t *testing.T) {
 			require.NotNil(t, enrichedCtx)
 		})
 	}
+}
+
+// TestFormatExitOutput covers the helper that builds the "(output: ...)"
+// suffix appended to non-zero-exit error messages.
+func TestFormatExitOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty output produces no suffix", func(t *testing.T) {
+		assert.Equal(t, "", formatExitOutput(nil))
+		assert.Equal(t, "", formatExitOutput([]byte{}))
+	})
+
+	t.Run("short output is quoted in full", func(t *testing.T) {
+		assert.Equal(t, ` (output: "boom")`, formatExitOutput([]byte("boom")))
+	})
+
+	t.Run("output exactly at limit is not truncated", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), exitOutputMaxBytes)
+		got := formatExitOutput(payload)
+		assert.Contains(t, got, "(output:")
+		assert.NotContains(t, got, "truncated")
+	})
+
+	t.Run("output over limit reports original byte count", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), exitOutputMaxBytes+5)
+		got := formatExitOutput(payload)
+		assert.Contains(t, got, "truncated from")
+		assert.Contains(t, got, "1029 bytes")
+	})
+
+	t.Run("control characters are escaped via %q", func(t *testing.T) {
+		got := formatExitOutput([]byte("line1\nline2\ttab"))
+		// %q renders newlines and tabs as literal \n / \t escape sequences.
+		assert.Contains(t, got, `\n`)
+		assert.Contains(t, got, `\t`)
+	})
 }


### PR DESCRIPTION
## Summary

When a WASM function returns a non-zero exit code, `execHelper` was discarding the `output` bytes and surfacing only the exit code:

```
function returned non-zero exit code: 1
```

Plugins commonly write a structured error to that output buffer, so diagnosing a misbehaving plugin meant blind-poking. Now the output is quoted into the error message:

```
function returned non-zero exit code: 1 (output: "{\"error\":\"boom\"}")
function returned non-zero exit code: 2 (output: "AAAAA...", truncated from 5000 bytes)
function returned non-zero exit code: 1            // empty output: no tail
```

### Implementation

- New unexported helper `formatExitOutput` builds the parenthesized suffix:
  - Empty output → `""` (no noisy `'(output: "")'` tail).
  - Output ≤ 1 KiB (`exitOutputMaxBytes`) → quoted in full via `%q`.
  - Larger → truncated, with the original byte count surfaced (`truncated from N bytes`).
- The pre-existing TODO comment (`should we return the output in this case?`) goes away.

### Tests

- Existing Eval-level `non-zero exit code` subtest now asserts the output substring is present in the wrapped error.
- exec-helper table refactored from `errContains string` to `errContainsAll []string` + `errExcludes []string` for richer multi-substring assertions. Two new entries cover **empty output** (verifying no `(output:` tail) and **2 KiB output** (verifying `truncated from 2048 bytes`).
- New `TestFormatExitOutput` covers the helper directly: empty, short, exactly at limit, over limit, control-character escaping via `%q`.

### Out of scope

- The richer `ExitError` type (#94 option 2) — public-API addition; defer to v1 alongside the `EvaluatorResponse` rewrite tracked in #86.

## Test plan

- [x] `go test -race -count=1 ./engines/extism/evaluator/...` — green
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet ./...` — clean
- [ ] CI on the PR

Closes #94

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_