### PR TITLE
feat(extism): WithExitOutputMaxBytes option to configure non-zero-exit error cap

### DIFF
--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -20,23 +20,45 @@ import (
 
 // Evaluator executes compiled WASM modules with provided runtime data
 type Evaluator struct {
-	execUnit   *script.ExecutableUnit
-	logHandler slog.Handler
-	logger     *slog.Logger
+	execUnit           *script.ExecutableUnit
+	logHandler         slog.Handler
+	logger             *slog.Logger
+	exitOutputMaxBytes int
 }
 
-// New creates a new Evaluator object
+// Option configures an [Evaluator]. Pass to [New].
+type Option func(*Evaluator)
+
+// WithExitOutputMaxBytes caps the WASM-output snippet included in non-zero-
+// exit-code error messages. A zero value (or unset) uses
+// [defaultExitOutputMaxBytes] (1024); a negative value disables the cap so
+// the full output is included unchanged.
+//
+// This mirrors the cap semantics of HTTPOptions.MaxBodySize from the
+// platform script loader.
+func WithExitOutputMaxBytes(n int) Option {
+	return func(e *Evaluator) { e.exitOutputMaxBytes = n }
+}
+
+// New creates a new Evaluator object.
 func New(
 	handler slog.Handler,
 	execUnit *script.ExecutableUnit,
+	opts ...Option,
 ) *Evaluator {
 	handler, logger := helpers.SetupLogger(handler, "extism", "Evaluator")
 
-	return &Evaluator{
+	e := &Evaluator{
 		execUnit:   execUnit,
 		logHandler: handler,
 		logger:     logger,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(e)
+		}
+	}
+	return e
 }
 
 func (be *Evaluator) String() string {
@@ -57,25 +79,35 @@ func (be *Evaluator) loadInputData(ctx context.Context) (map[string]any, error) 
 	return data.LoadInputData(ctx, be.logger.WithGroup("loadInputData"), be.getDataProvider())
 }
 
-// exitOutputMaxBytes caps the output snippet included in non-zero-exit
-// error messages so a multi-megabyte plugin payload can't blow up logs.
-const exitOutputMaxBytes = 1024
+// defaultExitOutputMaxBytes is the cap applied when an Evaluator is built
+// without [WithExitOutputMaxBytes] (or with the zero value). It keeps a
+// multi-megabyte plugin payload from blowing up logs while still surfacing
+// enough bytes for the host to diagnose a misbehaving plugin.
+const defaultExitOutputMaxBytes = 1024
 
 // formatExitOutput returns a parenthesized " (output: %q)" suffix for
 // inclusion in non-zero-exit-code errors. Returns "" when output is empty,
-// so callers don't get a noisy '(output: "")' tail. Long outputs are
-// truncated to exitOutputMaxBytes; the original byte length is surfaced
-// so callers can tell something was elided.
-func formatExitOutput(output []byte) string {
+// so callers don't get a noisy '(output: "")' tail.
+//
+// maxBytes governs truncation:
+//
+//   - zero  → fall back to [defaultExitOutputMaxBytes]
+//   - >0    → truncate at that value; the original byte length is surfaced
+//             so callers can tell something was elided
+//   - <0    → no cap; the full output is quoted unchanged
+func formatExitOutput(output []byte, maxBytes int) string {
 	if len(output) == 0 {
 		return ""
 	}
-	if len(output) <= exitOutputMaxBytes {
+	if maxBytes == 0 {
+		maxBytes = defaultExitOutputMaxBytes
+	}
+	if maxBytes < 0 || len(output) <= maxBytes {
 		return fmt.Sprintf(" (output: %q)", output)
 	}
 	return fmt.Sprintf(
 		" (output: %q, truncated from %d bytes)",
-		output[:exitOutputMaxBytes], len(output),
+		output[:maxBytes], len(output),
 	)
 }
 
@@ -87,6 +119,7 @@ func execHelper(
 	instance adapters.SdkPluginInstanceConfig,
 	entryPoint string,
 	inputJSON []byte,
+	exitOutputMaxBytes int,
 ) (any, time.Duration, error) {
 	// Call the function (context handles timeout)
 	startTime := time.Now()
@@ -101,7 +134,7 @@ func execHelper(
 	if exit != 0 {
 		return nil, execTime, fmt.Errorf(
 			"function returned non-zero exit code: %d%s",
-			exit, formatExitOutput(output),
+			exit, formatExitOutput(output, exitOutputMaxBytes),
 		)
 	}
 
@@ -146,7 +179,9 @@ func (be *Evaluator) exec(
 	}()
 
 	// Use the helper function for execution
-	result, execTime, err := execHelper(ctx, logger, instance, entryPoint, inputJSON)
+	result, execTime, err := execHelper(
+		ctx, logger, instance, entryPoint, inputJSON, be.exitOutputMaxBytes,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("extism execution error: %w", err)
 	}

--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -93,7 +93,7 @@ const defaultExitOutputMaxBytes = 1024
 //
 //   - zero  → fall back to [defaultExitOutputMaxBytes]
 //   - >0    → truncate at that value; the original byte length is surfaced
-//             so callers can tell something was elided
+//     so callers can tell something was elided
 //   - <0    → no cap; the full output is quoted unchanged
 func formatExitOutput(output []byte, maxBytes int) string {
 	if len(output) == 0 {

--- a/engines/extism/evaluator/evaluator.go
+++ b/engines/extism/evaluator/evaluator.go
@@ -26,20 +26,6 @@ type Evaluator struct {
 	exitOutputMaxBytes int
 }
 
-// Option configures an [Evaluator]. Pass to [New].
-type Option func(*Evaluator)
-
-// WithExitOutputMaxBytes caps the WASM-output snippet included in non-zero-
-// exit-code error messages. A zero value (or unset) uses
-// [defaultExitOutputMaxBytes] (1024); a negative value disables the cap so
-// the full output is included unchanged.
-//
-// This mirrors the cap semantics of HTTPOptions.MaxBodySize from the
-// platform script loader.
-func WithExitOutputMaxBytes(n int) Option {
-	return func(e *Evaluator) { e.exitOutputMaxBytes = n }
-}
-
 // New creates a new Evaluator object.
 func New(
 	handler slog.Handler,

--- a/engines/extism/evaluator/evaluator_test.go
+++ b/engines/extism/evaluator/evaluator_test.go
@@ -461,6 +461,43 @@ func TestEvaluator_Evaluate(t *testing.T) {
 			assert.Contains(t, err.Error(), "something went wrong")
 		})
 
+		// Regression for issue #122: WithExitOutputMaxBytes flows from
+		// Evaluator construction through exec → execHelper → formatExitOutput.
+		// A negative cap disables truncation, so a multi-KiB plugin payload
+		// makes it into the error string unchanged.
+		t.Run("non-zero exit code with WithExitOutputMaxBytes(-1)", func(t *testing.T) {
+			handler := slog.NewTextHandler(os.Stdout, nil)
+			ctxProvider := data.NewContextProvider(constants.EvalData)
+
+			payload := bytes.Repeat([]byte("Y"), defaultExitOutputMaxBytes*4)
+
+			mockPlugin := new(MockCompiledPlugin)
+			mockInstance := &mockPluginInstance{
+				exitCode: 7,
+				output:   payload,
+			}
+			mockPlugin.On("Instance", mock.Anything, mock.Anything).Return(mockInstance, nil)
+			mockPlugin.On("Close", mock.Anything).Return(nil)
+
+			content := createMockExecutable(mockPlugin, "main")
+			exe := &script.ExecutableUnit{
+				ID:           "test-error-exit-uncapped",
+				DataProvider: ctxProvider,
+				Content:      content,
+			}
+
+			evaluator := New(handler, exe, WithExitOutputMaxBytes(-1))
+			_, err := evaluator.Eval(t.Context())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "non-zero exit code: 7")
+			// No truncation tail.
+			assert.NotContains(t, err.Error(), "truncated from")
+			// The full payload survived end-to-end.
+			assert.Contains(t, err.Error(), string(payload[:32]))
+			assert.Contains(t, err.Error(), string(payload[len(payload)-32:]))
+		})
+
 		// Test error creating plugin instance
 		t.Run("error creating plugin instance", func(t *testing.T) {
 			handler := slog.NewTextHandler(os.Stdout, nil)
@@ -573,6 +610,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 				setup          func() (*mockPluginInstance, context.Context, context.CancelFunc)
 				entryPoint     string
 				input          []byte
+				maxBytes       int // exit-output cap; zero uses defaultExitOutputMaxBytes
 				wantErr        bool
 				errContainsAll []string
 				errExcludes    []string
@@ -621,14 +659,14 @@ func TestEvaluator_Evaluate(t *testing.T) {
 					errExcludes: []string{"(output:"},
 				},
 				{
-					// Sized as a multiple of exitOutputMaxBytes so the
-					// truncation branch keeps firing if the cap is raised.
-					name: "non-zero exit code with truncated output",
+					// Sized as a multiple of defaultExitOutputMaxBytes so the
+					// truncation branch keeps firing if the default is raised.
+					name: "non-zero exit code with truncated output (default cap)",
 					setup: func() (*mockPluginInstance, context.Context, context.CancelFunc) {
 						ctx, cancel := context.WithCancel(t.Context())
 						return &mockPluginInstance{
 							exitCode: 2,
-							output:   bytes.Repeat([]byte("X"), exitOutputMaxBytes*2),
+							output:   bytes.Repeat([]byte("X"), defaultExitOutputMaxBytes*2),
 						}, ctx, cancel
 					},
 					entryPoint: "main",
@@ -636,7 +674,46 @@ func TestEvaluator_Evaluate(t *testing.T) {
 					wantErr:    true,
 					errContainsAll: []string{
 						"non-zero exit code: 2",
-						fmt.Sprintf("truncated from %d bytes", exitOutputMaxBytes*2),
+						fmt.Sprintf("truncated from %d bytes", defaultExitOutputMaxBytes*2),
+					},
+				},
+				{
+					// Negative cap disables truncation; the full output is
+					// quoted into the error and there's no "truncated from"
+					// tail.
+					name: "non-zero exit code with disabled cap",
+					setup: func() (*mockPluginInstance, context.Context, context.CancelFunc) {
+						ctx, cancel := context.WithCancel(t.Context())
+						return &mockPluginInstance{
+							exitCode: 3,
+							output:   bytes.Repeat([]byte("Y"), defaultExitOutputMaxBytes*4),
+						}, ctx, cancel
+					},
+					entryPoint:     "main",
+					input:          []byte(`{"key":"value"}`),
+					maxBytes:       -1,
+					wantErr:        true,
+					errContainsAll: []string{"non-zero exit code: 3"},
+					errExcludes:    []string{"truncated from"},
+				},
+				{
+					// Small custom cap is honored and truncation kicks in
+					// before reaching the default.
+					name: "non-zero exit code with custom small cap",
+					setup: func() (*mockPluginInstance, context.Context, context.CancelFunc) {
+						ctx, cancel := context.WithCancel(t.Context())
+						return &mockPluginInstance{
+							exitCode: 4,
+							output:   []byte("0123456789ABCDEFGHIJ"),
+						}, ctx, cancel
+					},
+					entryPoint: "main",
+					input:      []byte(`{"key":"value"}`),
+					maxBytes:   4,
+					wantErr:    true,
+					errContainsAll: []string{
+						"non-zero exit code: 4",
+						"truncated from 20 bytes",
 					},
 				},
 				{
@@ -681,6 +758,7 @@ func TestEvaluator_Evaluate(t *testing.T) {
 						mockInstance,
 						tt.entryPoint,
 						tt.input,
+						tt.maxBytes,
 					)
 
 					// Verify the mock was called
@@ -841,31 +919,60 @@ func TestEvaluator_AddDataToContext(t *testing.T) {
 func TestFormatExitOutput(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty output produces no suffix", func(t *testing.T) {
-		assert.Empty(t, formatExitOutput(nil))
-		assert.Empty(t, formatExitOutput([]byte{}))
+	t.Run("empty output produces no suffix regardless of cap", func(t *testing.T) {
+		assert.Empty(t, formatExitOutput(nil, 0))
+		assert.Empty(t, formatExitOutput([]byte{}, 0))
+		assert.Empty(t, formatExitOutput(nil, 100))
+		assert.Empty(t, formatExitOutput(nil, -1))
 	})
 
-	t.Run("short output is quoted in full", func(t *testing.T) {
-		assert.Equal(t, ` (output: "boom")`, formatExitOutput([]byte("boom")))
+	t.Run("short output is quoted in full with default cap", func(t *testing.T) {
+		assert.Equal(t, ` (output: "boom")`, formatExitOutput([]byte("boom"), 0))
 	})
 
-	t.Run("output exactly at limit is not truncated", func(t *testing.T) {
-		payload := bytes.Repeat([]byte("a"), exitOutputMaxBytes)
-		got := formatExitOutput(payload)
+	t.Run("output exactly at default cap is not truncated", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), defaultExitOutputMaxBytes)
+		got := formatExitOutput(payload, 0)
 		assert.Contains(t, got, "(output:")
 		assert.NotContains(t, got, "truncated")
 	})
 
-	t.Run("output over limit reports original byte count", func(t *testing.T) {
-		payload := bytes.Repeat([]byte("a"), exitOutputMaxBytes+5)
-		got := formatExitOutput(payload)
+	t.Run("output over default cap reports original byte count", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), defaultExitOutputMaxBytes+5)
+		got := formatExitOutput(payload, 0)
 		assert.Contains(t, got, "truncated from")
 		assert.Contains(t, got, fmt.Sprintf("%d bytes", len(payload)))
 	})
 
+	t.Run("zero cap falls back to default", func(t *testing.T) {
+		// A 5-byte payload sits well below the 1024-byte default cap, so
+		// passing 0 must not truncate it.
+		got := formatExitOutput([]byte("short"), 0)
+		assert.Equal(t, ` (output: "short")`, got)
+	})
+
+	t.Run("negative cap disables truncation", func(t *testing.T) {
+		// A payload several multiples of the default cap must come back
+		// unchanged when the caller asks for no cap.
+		payload := bytes.Repeat([]byte("z"), defaultExitOutputMaxBytes*4)
+		got := formatExitOutput(payload, -1)
+		assert.Contains(t, got, "(output:")
+		assert.NotContains(t, got, "truncated")
+		// Output length is unbounded; verify the full payload made it in.
+		assert.Contains(t, got, string(payload[:64]))
+		assert.Contains(t, got, string(payload[len(payload)-64:]))
+	})
+
+	t.Run("positive cap honors the supplied limit", func(t *testing.T) {
+		// Payload of 20 bytes with a cap of 4 must truncate, reporting
+		// the original 20-byte length.
+		got := formatExitOutput([]byte("0123456789ABCDEFGHIJ"), 4)
+		assert.Contains(t, got, `"0123"`)
+		assert.Contains(t, got, "truncated from 20 bytes")
+	})
+
 	t.Run("control characters are escaped via %q", func(t *testing.T) {
-		got := formatExitOutput([]byte("line1\nline2\ttab"))
+		got := formatExitOutput([]byte("line1\nline2\ttab"), 0)
 		// %q renders newlines and tabs as literal \n / \t escape sequences.
 		assert.Contains(t, got, `\n`)
 		assert.Contains(t, got, `\t`)

--- a/engines/extism/evaluator/options.go
+++ b/engines/extism/evaluator/options.go
@@ -1,0 +1,15 @@
+package evaluator
+
+// Option configures an [Evaluator]. Pass to [New].
+type Option func(*Evaluator)
+
+// WithExitOutputMaxBytes caps the WASM-output snippet included in non-zero-
+// exit-code error messages. A zero value (or unset) uses
+// [defaultExitOutputMaxBytes] (1024); a negative value disables the cap so
+// the full output is included unchanged.
+//
+// This mirrors the cap semantics of HTTPOptions.MaxBodySize from the
+// platform script loader.
+func WithExitOutputMaxBytes(n int) Option {
+	return func(e *Evaluator) { e.exitOutputMaxBytes = n }
+}

--- a/engines/extism/new.go
+++ b/engines/extism/new.go
@@ -100,7 +100,11 @@ func FromExtismLoader(ldr loader.Loader, opts ...Option) (*evaluator.Evaluator, 
 		return nil, err
 	}
 
-	return evaluator.New(cfg.handler, execUnit), nil
+	return evaluator.New(
+		cfg.handler,
+		execUnit,
+		evaluator.WithExitOutputMaxBytes(cfg.exitOutputMaxBytes),
+	), nil
 }
 
 // NewCompiler creates a new Extism compiler using the functional options pattern.

--- a/engines/extism/options.go
+++ b/engines/extism/options.go
@@ -11,10 +11,11 @@ import (
 type Option func(*config)
 
 type config struct {
-	handler      slog.Handler
-	staticData   map[string]any
-	dataProvider data.Provider
-	entryPoint   string
+	handler            slog.Handler
+	staticData         map[string]any
+	dataProvider       data.Provider
+	entryPoint         string
+	exitOutputMaxBytes int
 }
 
 // WithLogHandler sets the slog.Handler used for diagnostic logging by the
@@ -48,4 +49,18 @@ func WithDataProvider(p data.Provider) Option {
 // option is omitted or the name is empty.
 func WithEntryPoint(name string) Option {
 	return func(c *config) { c.entryPoint = name }
+}
+
+// WithExitOutputMaxBytes caps the WASM-output snippet included in
+// non-zero-exit-code error messages produced by the evaluator.
+//
+//   - zero (or omitted) → use the default cap (1024 bytes)
+//   - positive          → truncate at that value; the original byte length
+//                         is surfaced in the error so callers can tell
+//                         something was elided
+//   - negative          → no cap; the full output is included unchanged
+//
+// Mirrors the cap semantics of HTTPOptions.MaxBodySize.
+func WithExitOutputMaxBytes(n int) Option {
+	return func(c *config) { c.exitOutputMaxBytes = n }
 }

--- a/engines/extism/options.go
+++ b/engines/extism/options.go
@@ -56,8 +56,8 @@ func WithEntryPoint(name string) Option {
 //
 //   - zero (or omitted) → use the default cap (1024 bytes)
 //   - positive          → truncate at that value; the original byte length
-//                         is surfaced in the error so callers can tell
-//                         something was elided
+//     is surfaced in the error so callers can tell
+//     something was elided
 //   - negative          → no cap; the full output is included unchanged
 //
 // Mirrors the cap semantics of HTTPOptions.MaxBodySize.

--- a/polyscript.go
+++ b/polyscript.go
@@ -206,8 +206,8 @@ func WithEntryPoint(name string) Option[Extism] {
 //
 //   - zero (or omitted) → use the default cap (1024 bytes)
 //   - positive          → truncate at that value; the original byte length
-//                         is surfaced in the error so callers can tell
-//                         something was elided
+//     is surfaced in the error so callers can tell
+//     something was elided
 //   - negative          → no cap; the full output is included unchanged
 //
 // Bound to [Extism] — passing it to [New[Risor]] or [New[Starlark]] is a

--- a/polyscript.go
+++ b/polyscript.go
@@ -171,9 +171,10 @@ func (s Source) resolve() (loader.Loader, error) {
 type Option[E Engine] func(*config)
 
 type config struct {
-	handler    slog.Handler
-	staticData map[string]any
-	entryPoint string
+	handler            slog.Handler
+	staticData         map[string]any
+	entryPoint         string
+	exitOutputMaxBytes int
 }
 
 // WithStaticData attaches a fixed map of values that the script will see
@@ -198,6 +199,21 @@ func WithLogHandler[E Engine](h slog.Handler) Option[E] {
 // [New[Starlark]] is a compile error rather than a silent no-op.
 func WithEntryPoint(name string) Option[Extism] {
 	return func(c *config) { c.entryPoint = name }
+}
+
+// WithExitOutputMaxBytes caps the WASM-output snippet included in
+// non-zero-exit-code error messages produced by the evaluator.
+//
+//   - zero (or omitted) → use the default cap (1024 bytes)
+//   - positive          → truncate at that value; the original byte length
+//                         is surfaced in the error so callers can tell
+//                         something was elided
+//   - negative          → no cap; the full output is included unchanged
+//
+// Bound to [Extism] — passing it to [New[Risor]] or [New[Starlark]] is a
+// compile-time error rather than a silent no-op.
+func WithExitOutputMaxBytes(n int) Option[Extism] {
+	return func(c *config) { c.exitOutputMaxBytes = n }
 }
 
 // ----------------------------------------------------------------------------
@@ -267,6 +283,7 @@ func newExtism(ldr loader.Loader, cfg *config) (platform.Evaluator, error) {
 	opts := []extismMachine.Option{
 		extismMachine.WithEntryPoint(cfg.entryPoint),
 		extismMachine.WithLogHandler(cfg.handler),
+		extismMachine.WithExitOutputMaxBytes(cfg.exitOutputMaxBytes),
 	}
 	if cfg.staticData != nil {
 		opts = append(opts, extismMachine.WithStaticData(cfg.staticData))

--- a/polyscript_options_test.go
+++ b/polyscript_options_test.go
@@ -148,6 +148,29 @@ func TestNewExtism(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "Hello, Test!", got["greeting"])
 	})
+
+	t.Run("WithExitOutputMaxBytes is accepted and a successful Eval still works", func(t *testing.T) {
+		// Construction-level test: verify the option is wired through
+		// newExtism → extism.WithExitOutputMaxBytes → evaluator.New
+		// without breaking the happy path. End-to-end truncation
+		// behavior is exercised at the evaluator layer in
+		// engines/extism/evaluator/evaluator_test.go (issue #122).
+		for _, n := range []int{-1, 0, 42, 8 * 1024} {
+			eval, err := polyscript.New[polyscript.Extism](
+				polyscript.FromBytes(wasmdata.TestModule),
+				polyscript.WithEntryPoint(wasmdata.EntrypointGreet),
+				polyscript.WithExitOutputMaxBytes(n),
+				polyscript.WithStaticData[polyscript.Extism](map[string]any{"input": "Cap"}),
+			)
+			require.NoError(t, err, "cap=%d", n)
+
+			result, err := eval.Eval(t.Context())
+			require.NoError(t, err, "cap=%d", n)
+			got, ok := result.Interface().(map[string]any)
+			require.True(t, ok, "cap=%d", n)
+			assert.Equal(t, "Hello, Cap!", got["greeting"], "cap=%d", n)
+		}
+	})
 }
 
 func TestFromLoader(t *testing.T) {


### PR DESCRIPTION
## Summary

PR #121 (closes #94) hard-coded a `1024`-byte cap on the WASM-output snippet included in non-zero-exit-code error messages. The cap is right for the default case but should be tunable — hosts may want a larger window for structured plugin payloads, or a smaller one for latency-sensitive logging.

Add a functional option at three layers:

```
polyscript.WithExitOutputMaxBytes(n)                Option[Extism]
  └─ engines/extism.WithExitOutputMaxBytes(n)       Option
       └─ engines/extism/evaluator.WithExitOutputMaxBytes(n)   evaluator.Option
            └─ Evaluator.exitOutputMaxBytes
                 └─ exec → execHelper → formatExitOutput(output, n)
```

### Behavior

Mirrors `HTTPOptions.MaxBodySize` from #98/#107:

| Value | Behavior |
|---|---|
| zero (or option omitted) | use default (1024 bytes) |
| positive | truncate at that value; original byte length surfaced |
| negative | no cap; full output included unchanged |

### Implementation notes

- Renamed `exitOutputMaxBytes` → `defaultExitOutputMaxBytes` to make zero-fallback semantics explicit.
- `formatExitOutput(output []byte, maxBytes int)` — `execHelper` threads the value through.
- `evaluator.New` gains a variadic `...Option` parameter; existing 15 callers continue to compile unchanged.
- Top-level `polyscript.WithExitOutputMaxBytes(n)` is `Option[Extism]` only — mirrors `WithEntryPoint`. Passing it to `New[Risor]` or `New[Starlark]` is a compile error rather than a silent no-op.

### Usage

```go
// Default behavior (1024-byte cap, unchanged)
eval, err := polyscript.New[polyscript.Extism](
    polyscript.FromBytes(wasmBytes),
    polyscript.WithEntryPoint("greet"),
)

// Disable cap entirely for a plugin with verbose structured errors
eval, err := polyscript.New[polyscript.Extism](
    polyscript.FromBytes(wasmBytes),
    polyscript.WithEntryPoint("greet"),
    polyscript.WithExitOutputMaxBytes(-1),
)

// Tighter cap for latency-sensitive logging
eval, err := polyscript.New[polyscript.Extism](
    polyscript.FromBytes(wasmBytes),
    polyscript.WithEntryPoint("greet"),
    polyscript.WithExitOutputMaxBytes(256),
)
```

### Tests

- `TestFormatExitOutput` refactored to drive `maxBytes` explicitly. New subtests for `zero falls back to default`, `negative disables truncation`, `positive cap honors limit`.
- `exec helper` table gains a `maxBytes int` column plus two new entries: `disabled cap` (negative, multi-KiB payload, no `truncated from` tail) and `custom small cap` (4-byte cap on a 20-byte payload).
- New `TestEvaluator_Evaluate/error_cases/non-zero exit code with WithExitOutputMaxBytes(-1)` drives `evaluator.New(..., WithExitOutputMaxBytes(-1))` end-to-end and verifies a multi-KiB payload survives in the wrapped error.
- New top-level `polyscript_options_test.go` subtest constructs `polyscript.New[Extism]` with four cap values (-1, 0, 42, 8 KiB) via `polyscript.WithExitOutputMaxBytes` and confirms the happy path still runs.

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [ ] CI (`golangci-lint`, Sonar, dependency review)

Closes #122

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_