### PR TITLE
cleanup: delete orphan *Executable structs from adapter packages

### DIFF
--- a/engines/extism/adapters/interfaces.go
+++ b/engines/extism/adapters/interfaces.go
@@ -6,10 +6,6 @@ import (
 	extismSDK "github.com/extism/go-sdk"
 )
 
-type ExtismExecutable struct {
-	GetExtismExecutable func() *extismSDK.CompiledPlugin
-}
-
 // CompiledPlugin is an interface for abstracting the extismSDK.CompiledPlugin
 type CompiledPlugin interface {
 	Instance(ctx context.Context, config extismSDK.PluginInstanceConfig) (PluginInstance, error)

--- a/engines/risor/adapters/interfaces.go
+++ b/engines/risor/adapters/interfaces.go
@@ -1,7 +1,0 @@
-package adapters
-
-import "github.com/deepnoodle-ai/risor/v2/pkg/bytecode"
-
-type RisorExecutable struct {
-	GetRisorByteCode func() *bytecode.Code
-}

--- a/engines/starlark/adapters/interfaces.go
+++ b/engines/starlark/adapters/interfaces.go
@@ -1,7 +1,0 @@
-package adapters
-
-import starlarkLib "go.starlark.net/starlark"
-
-type StarlarkExecutable struct {
-	GetStarlarkByteCode func() *starlarkLib.Program
-}


### PR DESCRIPTION
## Summary

Deletes three orphan struct types from the adapter packages, plus the two now-empty adapter directories that held the risor/starlark ones.

| Type | Location | Notes |
|---|---|---|
| `RisorExecutable` | `engines/risor/adapters/interfaces.go` | Sole content of the dir → whole dir deleted |
| `StarlarkExecutable` | `engines/starlark/adapters/interfaces.go` | Sole content of the dir → whole dir deleted |
| `ExtismExecutable` | `engines/extism/adapters/interfaces.go` | Only this struct (lines 9-11) removed — the `CompiledPlugin` / `PluginInstance` interfaces stay |

## Why

Investigating #101's "adapter coverage" piece (proposed `var _ Adapter = (*sdk.Whatever)(nil)` build-time assertions) turned up something different: those packages contain no interfaces — only these three orphan struct types holding function-pointer fields.

**Git archaeology** traced all three to the init commit (`0803be4`, July 2025) as an early exploration of a duck-typing pattern where compiled executables would expose bytecode via a callable field. The real implementation took a different path — each engine's `compiler` subpackage holds a concrete `Executable` struct with proper methods (e.g. `GetRisorByteCode()`), and the orphan struct was never linked to it. PR #18 (major reorg), PR #26 (machines→engines rename), and PR #74 (Risor v2 upgrade) each dragged the orphan files forward without removing them.

```
$ grep -rn 'RisorExecutable\|StarlarkExecutable\|ExtismExecutable' . --include='*.go'
engines/risor/adapters/interfaces.go:5:type RisorExecutable struct {
engines/starlark/adapters/interfaces.go:5:type StarlarkExecutable struct {
engines/extism/adapters/interfaces.go:9:type ExtismExecutable struct {
```

Three declarations, zero references — pure dead code.

```
$ grep -rn 'engines/risor/adapters\|engines/starlark/adapters' . --include='*.go' --include='*.md'
(no output)
```

No imports of the risor/starlark adapter package paths exist anywhere. Deleting the directories is safe.

## Public-API note

Technically a breaking change in form (three exported types removed, two exported packages removed), but:
- The types being removed are **unused and unreachable** from any caller.
- The repo is pre-v1; backwards-compat is not a goal (per recent direction).
- This is the kind of pre-v1 dead-code cut #104 anticipates for the larger v1 surface trim.

## Out of scope

- **#101's other four pieces** (cancellation tests, race test, CompositeProvider edge cases, HTTP loader error paths) — #101 stays open. The body's "adapter coverage" recommendation was misguided given the actual contents of those packages; the other four pieces are still valid.
- **#104** (delete `deprecated.go`) — separate v1-prep PR.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet ./...` — clean
- [ ] CI on the PR

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_