### PR TITLE
test(risor,starlark): regression test for Eval cancellation timing

### DIFF
--- a/engines/risor/evaluator/evaluator_test.go
+++ b/engines/risor/evaluator/evaluator_test.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/deepnoodle-ai/risor/v2/pkg/bytecode"
 	"github.com/robbyt/go-polyscript/engines/risor/compiler"
@@ -558,5 +560,62 @@ func TestEvaluator_AddDataToContext(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestEval_CancellationHaltsExecution verifies that cancelling the context
+// passed to Eval() halts the running script within a bounded time. The
+// script body is an unboundedly-long loop; only cancellation can return
+// it within the test deadline (issue #125).
+func TestEval_CancellationHaltsExecution(t *testing.T) {
+	t.Parallel()
+
+	handler := slog.NewTextHandler(io.Discard, nil)
+
+	// Condition-only Risor for-loop with a counter that would take far
+	// longer than the 2s test deadline to exhaust naturally; only ctx
+	// cancellation lets Eval return early.
+	// Risor v2 has no while/for-condition statements; iterate via a
+	// lazy range and the .each higher-order. The VM checks ctx.Done()
+	// periodically during execution (vm.go DefaultContextCheckInterval),
+	// so cancellation halts inside the .each call. Range count chosen
+	// so natural completion would far outrun the 2s test deadline.
+	const script = `
+range(1000000000).each(x => x)
+"done"
+`
+
+	ld, err := loader.NewFromString(script)
+	require.NoError(t, err)
+	ctxProvider := data.NewContextProvider(constants.EvalData)
+	exe, err := createTestExecutable(handler, ld, []string{constants.Ctx}, ctxProvider)
+	require.NoError(t, err)
+	eval := New(handler, exe)
+	require.NotNil(t, eval)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	ctx = context.WithValue(ctx, constants.EvalData, map[string]any{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := eval.Eval(ctx)
+		done <- err
+	}()
+
+	// Give the engine a moment to enter the spin loop, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.True(t,
+			errors.Is(err, context.Canceled) ||
+				strings.Contains(err.Error(), "context canceled") ||
+				strings.Contains(err.Error(), "cancel"),
+			"expected cancellation-shaped error, got: %v", err,
+		)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Eval did not return within 2s after cancel; cancellation unresponsive")
 	}
 }

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -2,12 +2,15 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http/httptest"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/robbyt/go-polyscript/engines/starlark/compiler"
 	"github.com/robbyt/go-polyscript/internal/helpers"
@@ -342,5 +345,55 @@ func TestEvaluator_AddDataToContext(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestEval_CancellationHaltsExecution is the regression companion to PR #81
+// (issue #125). PR #81 added a context.AfterFunc-registered thread.Cancel
+// in engines/starlark/evaluator/exec(); this test confirms the registered
+// cancellation actually halts a running script within a bounded time. The
+// script body is an unboundedly-long loop; only cancellation can return
+// it within the test deadline.
+func TestEval_CancellationHaltsExecution(t *testing.T) {
+	t.Parallel()
+
+	// Lazy range(); cancellation halts at the next instruction boundary
+	// via the AfterFunc-registered thread.Cancel().
+	const scriptContent = `
+def spin():
+    for i in range(1000000000000):
+        pass
+    return "done"
+
+result = spin()
+`
+	_, eval := evalBuilder(t, scriptContent)
+
+	// evalBuilder uses a ContextProvider with constants.EvalData; populate
+	// it with an empty map so loadInputData has the value to read.
+	ctx, cancel := context.WithCancel(t.Context())
+	ctx = context.WithValue(ctx, constants.EvalData, map[string]any{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := eval.Eval(ctx)
+		done <- err
+	}()
+
+	// Give the engine a moment to enter the spin loop, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.True(t,
+			errors.Is(err, context.Canceled) ||
+				strings.Contains(err.Error(), "context canceled") ||
+				strings.Contains(err.Error(), "cancel"),
+			"expected cancellation-shaped error, got: %v", err,
+		)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Eval did not return within 2s after cancel; cancellation unresponsive")
 	}
 }


### PR DESCRIPTION
## Summary

PR #81 added `context.AfterFunc(ctx, thread.Cancel)` to Starlark's `exec()` to fix a goroutine leak, but no test asserted that **cancellation actually halts execution within a bounded time**. Same gap existed for Risor — the Risor v2 VM checks `ctx.Done()` at `DefaultContextCheckInterval` (1000 instructions) and via a background goroutine, but nothing locked the behavior in. Extism is already covered by the `execHelper` cancellation cases added in PR #121.

Adds `TestEval_CancellationHaltsExecution` to both Risor and Starlark evaluator test files. The script body is a long-running loop sized so natural completion would far outrun the 2-second test deadline; only ctx cancellation can return `Eval` early.

### Script bodies

| Engine | Long-running construct | Why |
|---|---|---|
| Risor | `range(1e9).each(x => x)` | Risor v2 has no for/while statements (functional, uses `.map`/`.filter`/`.each`). The VM's periodic ctx-check inside `.each`'s `callable.Call` propagates cancellation. |
| Starlark | `for i in range(1e12): pass` inside `def spin(): ...` | Lazy range + Python-style loop. The AfterFunc-registered `thread.Cancel` halts at the next instruction boundary. |

### Test shape

Both tests:

1. Launch `Eval` in a goroutine.
2. Sleep 50ms so the engine is observably mid-script.
3. Cancel the context.
4. Assert `Eval` returns within 2s with a cancellation-shaped error — `errors.Is(context.Canceled)` OR a `"context canceled"` / `"cancel"` substring (Starlark's `thread.Cancel` wraps the reason in an `EvalError` that doesn't unwrap to `context.Canceled`).

### Stress test

Locally ran `go test -race -count=20 -run TestEval_CancellationHaltsExecution ./engines/risor/evaluator/... ./engines/starlark/evaluator/...` — 40 runs, zero flakes, ~2 seconds total wall time.

### Out of scope

- `Eval`-halts-on-deadline (`context.WithTimeout`) — same code path as cancel.
- Extism — already covered.

## Test plan

- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go test -race -count=20` on the two new tests — no flakes
- [x] `go vet ./...` — clean
- [ ] CI

Closes #125

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_