### PR TITLE
fix(data): deep-copy nested maps in ContextProvider.AddDataToContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ ctx, _ := provider.AddDataToContext(parent, requestData)
 ctx, _ = provider.AddDataToContext(ctx, moreData)  // build on the returned ctx
 ```
 
-Reference-typed values stored in the map (slices, pointers, channels, function values, and maps **other than** `map[string]any`) remain shared with the caller after `AddDataToContext` returns. The provider never mutates them, but callers should avoid mutating them either. The deep-copy guarantee applies specifically to `map[string]any` values — `processValue` and `deepCopyMap` recurse into those; other map types (e.g. `map[string]string`, `map[any]any`) are passed through as opaque values. Value types (int, string, struct, etc.) are copied as usual when stored in an `any` slot. `*http.Request` and `http.Request` inputs are converted to `map[string]any` via `helpers.RequestToMap` on the way in, so the underlying request itself is not retained.
+For the details of which value kinds are deep-copied versus stored by reference, see the [`AddDataToContext` godoc](https://pkg.go.dev/github.com/robbyt/go-polyscript/platform/data#ContextProvider.AddDataToContext).
 
 ### Combining Static and Dynamic Runtime Data
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ ctx, _ := provider.AddDataToContext(parent, requestData)
 ctx, _ = provider.AddDataToContext(ctx, moreData)  // build on the returned ctx
 ```
 
-Non-map values stored via `AddDataToContext` (slices, structs, `*http.Request`) are passed through by reference rather than copied. Callers must not mutate those values after handing them in; the provider itself never does.
+Reference-typed values stored in the map (slices, pointers, channels, function values) remain shared with the caller after `AddDataToContext` returns. The provider never mutates them, but callers should avoid mutating them either. Value types (int, string, struct, etc.) are copied as usual when stored in an `any` slot. `*http.Request` and `http.Request` inputs are converted to maps via `helpers.RequestToMap` on the way in, so the underlying request itself is not retained.
 
 ### Combining Static and Dynamic Runtime Data
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The top-level package (`polyscript.go`) exposes a single generic constructor —
 
 - **Unified Abstraction API**: Common interfaces and implementations for several scripting languages
 - **Flexible Engine Selection**: Easily switch between different script engines
-- **Thread-safe Data Management**: Multiple ways to provide input data to scripts
+- **Context-derived Data**: Per-request data threads through Go's `context.Context` via a derived-context pattern that's safe across goroutines when each request owns its own chain (see [Concurrency](#concurrency-and-thread-safety)).
 - **Compilation, Evaluation, and Data Handling**: Compile scripts once with static data when creating the evaluator instance, then run multiple evaluation executions with variable runtime input.
 
 ## Engines Implemented
@@ -196,6 +196,14 @@ enrichedCtx, _ := evaluator.AddDataToContext(context.Background(), runtimeData)
 // Execute with the "enriched" context containing the link to the input data
 result, _ := evaluator.Eval(enrichedCtx)
 ```
+
+#### Concurrency and thread-safety
+
+`ContextProvider.AddDataToContext` is safe for the **per-request derived-context** pattern: each goroutine starts from its own context and threads the returned context forward for any subsequent enrichment. Multiple goroutines using independent context chains do not interfere with each other.
+
+Concurrent enrichment of a **shared parent context that already contains nested maps** is *not* safe. `AddDataToContext` shallow-copies the existing top-level map when deriving the new context; nested maps inside that map are reference-shared with the parent and are mutated in place during recursive merge. Two goroutines enriching such a shared parent with overlapping nested keys will race.
+
+If your usage looks like "fan out N goroutines, each enriches the same base context with its own slice of data," give each goroutine its own root context (e.g. `context.Background()` or `t.Context()`) and merge results at a join point on the caller side, rather than sharing a base context that has already been enriched with nested data.
 
 ### Combining Static and Dynamic Runtime Data
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The top-level package (`polyscript.go`) exposes a single generic constructor —
 
 - **Unified Abstraction API**: Common interfaces and implementations for several scripting languages
 - **Flexible Engine Selection**: Easily switch between different script engines
-- **Thread-safe Data Management**: Per-request data flows through Go's `context.Context` via a derived-context pattern. Each `AddDataToContext` call returns a context independent of its parent (nested maps are deep-copied), so concurrent enrichments from goroutines that share a parent never race — see [Concurrency](#concurrency-and-thread-safety).
+- **Thread-safe Data Management**: Multiple ways to provide input data to scripts
 - **Compilation, Evaluation, and Data Handling**: Compile scripts once with static data when creating the evaluator instance, then run multiple evaluation executions with variable runtime input.
 
 ## Engines Implemented

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The top-level package (`polyscript.go`) exposes a single generic constructor —
 
 - **Unified Abstraction API**: Common interfaces and implementations for several scripting languages
 - **Flexible Engine Selection**: Easily switch between different script engines
-- **Context-derived Data**: Per-request data threads through Go's `context.Context` via a derived-context pattern that's safe across goroutines when each request owns its own chain (see [Concurrency](#concurrency-and-thread-safety)).
+- **Thread-safe Data Management**: Per-request data flows through Go's `context.Context` via a derived-context pattern. Each `AddDataToContext` call returns a context independent of its parent (nested maps are deep-copied), so concurrent enrichments from goroutines that share a parent never race — see [Concurrency](#concurrency-and-thread-safety).
 - **Compilation, Evaluation, and Data Handling**: Compile scripts once with static data when creating the evaluator instance, then run multiple evaluation executions with variable runtime input.
 
 ## Engines Implemented
@@ -199,11 +199,18 @@ result, _ := evaluator.Eval(enrichedCtx)
 
 #### Concurrency and thread-safety
 
-`ContextProvider.AddDataToContext` is safe for the **per-request derived-context** pattern: each goroutine starts from its own context and threads the returned context forward for any subsequent enrichment. Multiple goroutines using independent context chains do not interfere with each other.
+`ContextProvider.AddDataToContext` is safe for concurrent use. Each call returns a derived context independent of its parent: data merged into the derived context never affects the parent or any sibling derived chain.
 
-Concurrent enrichment of a **shared parent context that already contains nested maps** is *not* safe. `AddDataToContext` shallow-copies the existing top-level map when deriving the new context; nested maps inside that map are reference-shared with the parent and are mutated in place during recursive merge. Two goroutines enriching such a shared parent with overlapping nested keys will race.
+Existing data from the parent context is deep-copied at every nesting level when forming the derived context, so concurrent enrichments from goroutines that share a parent context — even one already populated with nested maps — do not race on shared inner storage.
 
-If your usage looks like "fan out N goroutines, each enriches the same base context with its own slice of data," give each goroutine its own root context (e.g. `context.Background()` or `t.Context()`) and merge results at a join point on the caller side, rather than sharing a base context that has already been enriched with nested data.
+The typical pattern is one derived-context chain per request, with the returned context threaded forward for any subsequent enrichment:
+
+```go
+ctx, _ := provider.AddDataToContext(parent, requestData)
+ctx, _ = provider.AddDataToContext(ctx, moreData)  // build on the returned ctx
+```
+
+Non-map values stored via `AddDataToContext` (slices, structs, `*http.Request`) are passed through by reference rather than copied. Callers must not mutate those values after handing them in; the provider itself never does.
 
 ### Combining Static and Dynamic Runtime Data
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ result, _ := evaluator.Eval(enrichedCtx)
 
 `ContextProvider.AddDataToContext` is safe for concurrent use. Each call returns a derived context independent of its parent: data merged into the derived context never affects the parent or any sibling derived chain.
 
-Existing data from the parent context is deep-copied at every nesting level when forming the derived context, so concurrent enrichments from goroutines that share a parent context — even one already populated with nested maps — do not race on shared inner storage.
+Existing data from the parent context is deep-copied when forming the derived context, so concurrent enrichments from goroutines that share a parent context — even one already populated with nested maps — do not race on shared inner map storage.
 
 The typical pattern is one derived-context chain per request, with the returned context threaded forward for any subsequent enrichment:
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ ctx, _ := provider.AddDataToContext(parent, requestData)
 ctx, _ = provider.AddDataToContext(ctx, moreData)  // build on the returned ctx
 ```
 
-Reference-typed values stored in the map (slices, pointers, channels, function values) remain shared with the caller after `AddDataToContext` returns. The provider never mutates them, but callers should avoid mutating them either. Value types (int, string, struct, etc.) are copied as usual when stored in an `any` slot. `*http.Request` and `http.Request` inputs are converted to maps via `helpers.RequestToMap` on the way in, so the underlying request itself is not retained.
+Reference-typed values stored in the map (slices, pointers, channels, function values, and maps **other than** `map[string]any`) remain shared with the caller after `AddDataToContext` returns. The provider never mutates them, but callers should avoid mutating them either. The deep-copy guarantee applies specifically to `map[string]any` values — `processValue` and `deepCopyMap` recurse into those; other map types (e.g. `map[string]string`, `map[any]any`) are passed through as opaque values. Value types (int, string, struct, etc.) are copied as usual when stored in an `any` slot. `*http.Request` and `http.Request` inputs are converted to `map[string]any` via `helpers.RequestToMap` on the way in, so the underlying request itself is not retained.
 
 ### Combining Static and Dynamic Runtime Data
 

--- a/platform/data/contextProvider.go
+++ b/platform/data/contextProvider.go
@@ -58,9 +58,16 @@ func (p *ContextProvider) GetData(ctx context.Context) (map[string]any, error) {
 // chain. Existing data from the parent context is deep-copied at every
 // nesting level when forming the derived context, so concurrent
 // enrichments from goroutines that share a parent never race on shared
-// inner map storage. (Non-map values such as slices, structs, and
-// *http.Request are passed through by reference; callers must not
-// mutate those after handing them to AddDataToContext.)
+// inner map storage.
+//
+// Reference-typed values stored in the map (slices, pointers, channels,
+// function values) remain shared with the source — ContextProvider
+// never mutates them in place, but callers should avoid mutating them
+// after handing them to AddDataToContext. Value types (int, string,
+// struct, etc.) are copied as usual when stored in an `any` slot.
+// *http.Request and http.Request inputs are converted to maps via
+// helpers.RequestToMap on the way in, so the underlying request is not
+// stored.
 //
 // The typical pattern is one derived-context chain per request, with
 // the returned context threaded forward for any subsequent enrichment.
@@ -166,17 +173,20 @@ func (p *ContextProvider) mergeIntoMap(
 }
 
 // deepCopyMap returns a recursive copy of m. Nested map[string]any values
-// are allocated fresh at every level so the returned map shares no
-// mutable map storage with m. Other values (slices, structs, primitives,
-// *http.Request) are passed through by reference — ContextProvider never
-// mutates them in place after storing, but callers must not mutate them
-// either.
+// are allocated fresh at every level so the returned map shares no mutable
+// map storage with m.
 //
-// Returns nil when m is nil.
+// Always returns a non-nil map, even when m is nil or empty; this lets
+// AddDataToContext use the result directly without a separate guard
+// against a nil parent-context value.
+//
+// Non-map values are stored by assignment to an `any` slot. Value types
+// (int, string, struct, etc.) are copied as usual; reference types
+// (slices, pointers, channels, function values) remain shared with the
+// source. ContextProvider never mutates stored values in place; callers
+// should avoid mutating reference-typed values after handing them to
+// AddDataToContext.
 func deepCopyMap(m map[string]any) map[string]any {
-	if m == nil {
-		return nil
-	}
 	out := make(map[string]any, len(m))
 	for k, v := range m {
 		if nested, ok := v.(map[string]any); ok {

--- a/platform/data/contextProvider.go
+++ b/platform/data/contextProvider.go
@@ -50,6 +50,24 @@ func (p *ContextProvider) GetData(ctx context.Context) (map[string]any, error) {
 // and later values override earlier ones for duplicate keys.
 //
 // See README.md for detailed usage examples.
+//
+// # Concurrency
+//
+// Each caller MUST use the returned context for any subsequent
+// enrichment. The supported pattern is one derived-context chain per
+// request: independent chains do not share mutable state and are safe
+// to operate on concurrently.
+//
+// Concurrent calls from goroutines that share a parent context already
+// populated with nested maps are NOT safe. The top-level map is
+// shallow-copied via [maps.Copy], so nested-map references survive into
+// the new derived context. The recursive merge in [mergeIntoMap]
+// mutates those nested maps in place, which races if another goroutine
+// is concurrently reading or merging the same parent.
+//
+// If you need to enrich a single context from multiple goroutines, give
+// each goroutine its own root context and merge results at a host-side
+// join point — do not share an already-enriched parent.
 func (p *ContextProvider) AddDataToContext(
 	ctx context.Context,
 	data ...map[string]any,

--- a/platform/data/contextProvider.go
+++ b/platform/data/contextProvider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
 
 	"github.com/robbyt/go-polyscript/internal/helpers"
@@ -53,21 +52,18 @@ func (p *ContextProvider) GetData(ctx context.Context) (map[string]any, error) {
 //
 // # Concurrency
 //
-// Each caller MUST use the returned context for any subsequent
-// enrichment. The supported pattern is one derived-context chain per
-// request: independent chains do not share mutable state and are safe
-// to operate on concurrently.
+// AddDataToContext is safe for concurrent use. Each call returns a
+// derived context independent of its parent: data merged into the
+// derived context does not affect the parent or any sibling derived
+// chain. Existing data from the parent context is deep-copied at every
+// nesting level when forming the derived context, so concurrent
+// enrichments from goroutines that share a parent never race on shared
+// inner map storage. (Non-map values such as slices, structs, and
+// *http.Request are passed through by reference; callers must not
+// mutate those after handing them to AddDataToContext.)
 //
-// Concurrent calls from goroutines that share a parent context already
-// populated with nested maps are NOT safe. The top-level map is
-// shallow-copied via [maps.Copy], so nested-map references survive into
-// the new derived context. The recursive merge in [mergeIntoMap]
-// mutates those nested maps in place, which races if another goroutine
-// is concurrently reading or merging the same parent.
-//
-// If you need to enrich a single context from multiple goroutines, give
-// each goroutine its own root context and merge results at a host-side
-// join point — do not share an already-enriched parent.
+// The typical pattern is one derived-context chain per request, with
+// the returned context threaded forward for any subsequent enrichment.
 func (p *ContextProvider) AddDataToContext(
 	ctx context.Context,
 	data ...map[string]any,
@@ -81,7 +77,10 @@ func (p *ContextProvider) AddDataToContext(
 
 	if existingData := ctx.Value(p.contextKey); existingData != nil {
 		if existingMap, ok := existingData.(map[string]any); ok {
-			maps.Copy(toStore, existingMap)
+			// Deep-copy nested maps so subsequent in-place merge into
+			// toStore cannot race with goroutines reading or merging the
+			// same parent context. See the # Concurrency note above.
+			toStore = deepCopyMap(existingMap)
 		}
 	}
 
@@ -164,4 +163,27 @@ func (p *ContextProvider) mergeIntoMap(
 
 	// Non-map values simply replace existing values
 	target[key] = value
+}
+
+// deepCopyMap returns a recursive copy of m. Nested map[string]any values
+// are allocated fresh at every level so the returned map shares no
+// mutable map storage with m. Other values (slices, structs, primitives,
+// *http.Request) are passed through by reference — ContextProvider never
+// mutates them in place after storing, but callers must not mutate them
+// either.
+//
+// Returns nil when m is nil.
+func deepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			out[k] = deepCopyMap(nested)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
 }

--- a/platform/data/contextProvider.go
+++ b/platform/data/contextProvider.go
@@ -61,11 +61,15 @@ func (p *ContextProvider) GetData(ctx context.Context) (map[string]any, error) {
 // inner map storage.
 //
 // Reference-typed values stored in the map (slices, pointers, channels,
-// function values) remain shared with the source — ContextProvider
-// never mutates them in place, but callers should avoid mutating them
-// after handing them to AddDataToContext. Value types (int, string,
-// struct, etc.) are copied as usual when stored in an `any` slot.
-// *http.Request and http.Request inputs are converted to maps via
+// function values, and maps OTHER than map[string]any) remain shared
+// with the source — ContextProvider never mutates them in place, but
+// callers should avoid mutating them after handing them to
+// AddDataToContext. The deep-copy guarantee applies specifically to
+// map[string]any values, which processValue and deepCopyMap recurse
+// into; other map types (e.g. map[string]string, map[any]any) are
+// stored as opaque values. Value types (int, string, struct, etc.) are
+// copied as usual when stored in an `any` slot. *http.Request and
+// http.Request inputs are converted to map[string]any via
 // helpers.RequestToMap on the way in, so the underlying request is not
 // stored.
 //

--- a/platform/data/contextProvider_test.go
+++ b/platform/data/contextProvider_test.go
@@ -602,13 +602,13 @@ func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
-		go func(id int) {
+	for id := range goroutines {
+		go func() {
 			defer wg.Done()
 
 			// Per-request derived ctx — the documented safe pattern.
 			ctx := t.Context()
-			for j := 0; j < iterations; j++ {
+			for j := range iterations {
 				key := fmt.Sprintf("g%d-iter%d", id, j)
 				next, err := p.AddDataToContext(ctx, map[string]any{key: j})
 				if err != nil {
@@ -628,7 +628,7 @@ func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 				}
 				ctx = next
 			}
-		}(i)
+		}()
 	}
 	wg.Wait()
 }

--- a/platform/data/contextProvider_test.go
+++ b/platform/data/contextProvider_test.go
@@ -586,6 +586,30 @@ func TestContextProvider_DataIntegration(t *testing.T) {
 	})
 }
 
+// TestContextProvider_AddDataToContext_TypedNilParent guards against a
+// regression caught in Copilot review of #93: if a typed-nil map[string]any
+// is stored in the context value (e.g. `context.WithValue(parent, key,
+// (map[string]any)(nil))`), the parent map ranges as empty, deepCopyMap
+// must still produce a usable non-nil destination, and the subsequent
+// merge must not panic with "assignment to entry in nil map".
+func TestContextProvider_AddDataToContext_TypedNilParent(t *testing.T) {
+	t.Parallel()
+	p := NewContextProvider(constants.EvalData)
+
+	var typedNil map[string]any
+	parent := context.WithValue(t.Context(), constants.EvalData, typedNil)
+
+	// This call would have panicked under the early-return-nil version
+	// of deepCopyMap (toStore = nil → mergeIntoMap → assignment to entry
+	// in nil map).
+	next, err := p.AddDataToContext(parent, map[string]any{"k": "v"})
+	require.NoError(t, err)
+
+	got, err := p.GetData(next)
+	require.NoError(t, err)
+	assert.Equal(t, "v", got["k"])
+}
+
 // TestContextProvider_AddDataToContext_Concurrent is the regression test
 // for the deep-copy fix in #93. Goroutines share an already-enriched
 // parent context whose value contains a nested map. Each goroutine

--- a/platform/data/contextProvider_test.go
+++ b/platform/data/contextProvider_test.go
@@ -2,7 +2,9 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/robbyt/go-polyscript/platform/constants"
@@ -582,4 +584,51 @@ func TestContextProvider_DataIntegration(t *testing.T) {
 		require.Error(t, err, "Should reject empty keys")
 		assert.Contains(t, err.Error(), "empty keys are not allowed")
 	})
+}
+
+// TestContextProvider_AddDataToContext_Concurrent exercises the documented
+// per-request derived-context pattern under -race: each goroutine starts
+// from its own root context, threads the returned context through repeated
+// AddDataToContext calls, and reads its own data back. Independent chains
+// must not interfere — this test asserts the contract narrowed in #93's
+// godoc and README updates.
+func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	p := NewContextProvider(constants.EvalData)
+
+	const goroutines = 32
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+
+			// Per-request derived ctx — the documented safe pattern.
+			ctx := t.Context()
+			for j := 0; j < iterations; j++ {
+				key := fmt.Sprintf("g%d-iter%d", id, j)
+				next, err := p.AddDataToContext(ctx, map[string]any{key: j})
+				if err != nil {
+					t.Errorf("goroutine %d iter %d: %v", id, j, err)
+					return
+				}
+				// Read-back invariant: our derived chain must contain our key.
+				got, err := p.GetData(next)
+				if err != nil {
+					t.Errorf("goroutine %d iter %d GetData: %v", id, j, err)
+					return
+				}
+				if got[key] != j {
+					t.Errorf("goroutine %d iter %d: got[%q] = %v, want %d",
+						id, j, key, got[key], j)
+					return
+				}
+				ctx = next
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/platform/data/contextProvider_test.go
+++ b/platform/data/contextProvider_test.go
@@ -587,10 +587,12 @@ func TestContextProvider_DataIntegration(t *testing.T) {
 }
 
 // TestContextProvider_AddDataToContext_Concurrent exercises the documented
-// per-request derived-context pattern under -race: each goroutine starts
-// from its own root context, threads the returned context through repeated
-// AddDataToContext calls, and reads its own data back. Independent chains
-// must not interfere — this test asserts the contract narrowed in #93's
+// safe concurrency pattern under -race: each goroutine builds its own
+// derived-context chain off a shared, un-enriched root (t.Context()),
+// threads the returned context through repeated AddDataToContext calls,
+// and reads its own data back. The root carries no nested maps, so the
+// chains never race on shared inner storage — independent chains must
+// not interfere. This test asserts the contract narrowed in #93's
 // godoc and README updates.
 func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 	t.Parallel()
@@ -606,7 +608,7 @@ func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			// Per-request derived ctx — the documented safe pattern.
+			// Shared un-enriched root; per-goroutine derived chain on top.
 			ctx := t.Context()
 			for j := range iterations {
 				key := fmt.Sprintf("g%d-iter%d", id, j)

--- a/platform/data/contextProvider_test.go
+++ b/platform/data/contextProvider_test.go
@@ -612,20 +612,18 @@ func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 			ctx := t.Context()
 			for j := range iterations {
 				key := fmt.Sprintf("g%d-iter%d", id, j)
+
 				next, err := p.AddDataToContext(ctx, map[string]any{key: j})
-				if err != nil {
-					t.Errorf("goroutine %d iter %d: %v", id, j, err)
+				if !assert.NoErrorf(t, err, "goroutine %d iter %d", id, j) {
 					return
 				}
+
 				// Read-back invariant: our derived chain must contain our key.
 				got, err := p.GetData(next)
-				if err != nil {
-					t.Errorf("goroutine %d iter %d GetData: %v", id, j, err)
+				if !assert.NoErrorf(t, err, "goroutine %d iter %d GetData", id, j) {
 					return
 				}
-				if got[key] != j {
-					t.Errorf("goroutine %d iter %d: got[%q] = %v, want %d",
-						id, j, key, got[key], j)
+				if !assert.Equalf(t, j, got[key], "goroutine %d iter %d key=%q", id, j, key) {
 					return
 				}
 				ctx = next

--- a/platform/data/contextProvider_test.go
+++ b/platform/data/contextProvider_test.go
@@ -586,18 +586,28 @@ func TestContextProvider_DataIntegration(t *testing.T) {
 	})
 }
 
-// TestContextProvider_AddDataToContext_Concurrent exercises the documented
-// safe concurrency pattern under -race: each goroutine builds its own
-// derived-context chain off a shared, un-enriched root (t.Context()),
-// threads the returned context through repeated AddDataToContext calls,
-// and reads its own data back. The root carries no nested maps, so the
-// chains never race on shared inner storage — independent chains must
-// not interfere. This test asserts the contract narrowed in #93's
-// godoc and README updates.
+// TestContextProvider_AddDataToContext_Concurrent is the regression test
+// for the deep-copy fix in #93. Goroutines share an already-enriched
+// parent context whose value contains a nested map. Each goroutine
+// enriches the SAME nested key with its own data and reads it back.
+// Before the deep-copy fix, the recursive merge mutated the nested map
+// in-place — concurrent goroutines raced on shared inner storage and
+// -race would fire. The fix deep-copies nested maps when deriving from
+// the parent so each derived chain owns its own nested map storage.
+//
+// 32 goroutines × 100 iterations = 3200 enrichment + read-back checks
+// against a shared parent. Passes cleanly under -race.
 func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 	t.Parallel()
 
 	p := NewContextProvider(constants.EvalData)
+
+	// Pre-enrich a shared root with a nested map. This is the exact
+	// shape that was unsafe under the old shallow-copy implementation.
+	parent, err := p.AddDataToContext(t.Context(), map[string]any{
+		"shared": map[string]any{"baseline": "from-parent"},
+	})
+	require.NoError(t, err)
 
 	const goroutines = 32
 	const iterations = 100
@@ -608,22 +618,36 @@ func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			// Shared un-enriched root; per-goroutine derived chain on top.
-			ctx := t.Context()
+			// All goroutines start from the SAME enriched parent.
+			ctx := parent
 			for j := range iterations {
 				key := fmt.Sprintf("g%d-iter%d", id, j)
 
-				next, err := p.AddDataToContext(ctx, map[string]any{key: j})
+				// Enrich the nested "shared" map with our own key. Before
+				// the fix this was the racing path: mergeIntoMap recursed
+				// into parent.shared and mutated it concurrently.
+				next, err := p.AddDataToContext(ctx, map[string]any{
+					"shared": map[string]any{key: j},
+				})
 				if !assert.NoErrorf(t, err, "goroutine %d iter %d", id, j) {
 					return
 				}
 
-				// Read-back invariant: our derived chain must contain our key.
+				// Read-back invariant: our derived chain must contain
+				// our key under "shared", plus the baseline from parent.
 				got, err := p.GetData(next)
 				if !assert.NoErrorf(t, err, "goroutine %d iter %d GetData", id, j) {
 					return
 				}
-				if !assert.Equalf(t, j, got[key], "goroutine %d iter %d key=%q", id, j, key) {
+				shared, ok := got["shared"].(map[string]any)
+				if !assert.Truef(t, ok, "goroutine %d iter %d: shared not a map", id, j) {
+					return
+				}
+				if !assert.Equalf(t, j, shared[key], "goroutine %d iter %d shared[%q]", id, j, key) {
+					return
+				}
+				if !assert.Equalf(t, "from-parent", shared["baseline"],
+					"goroutine %d iter %d: parent baseline lost", id, j) {
 					return
 				}
 				ctx = next
@@ -631,4 +655,13 @@ func TestContextProvider_AddDataToContext_Concurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
+	// Parent context must be unchanged after all the concurrent
+	// enrichment — the deep-copy fix guarantees independence.
+	parentData, err := p.GetData(parent)
+	require.NoError(t, err)
+	parentShared, ok := parentData["shared"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "from-parent", parentShared["baseline"])
+	require.Len(t, parentShared, 1, "parent.shared must hold only the baseline key; got %v", parentShared)
 }


### PR DESCRIPTION
## Summary

Fixes a nested-map race in `ContextProvider.AddDataToContext` and walks the docs forward to reflect the now-honest thread-safety contract.

> Note: this PR's scope expanded mid-flight. It started as a doc-narrow change (acknowledge the existing nested-map race in the README and godoc), and pivoted to a real bug fix (deep-copy nested maps so the race can't happen) per the reviewer's request. See commit history for the progression.

## The bug

`AddDataToContext` shallow-copied the parent context's top-level map into a fresh `toStore` via `maps.Copy`, then recursively merged incoming data via `mergeIntoMap`. The recursive merge mutates nested maps in place — and because `maps.Copy` is shallow, those nested maps were the **same map references** held by the parent context. Two goroutines enriching the same parent with overlapping nested keys raced on shared inner storage, producing either a `-race` data-race report or a runtime `fatal error: concurrent map writes`.

## The fix

New `deepCopyMap` helper allocates a fresh `map[string]any` at every nesting level. `AddDataToContext` uses it in place of `maps.Copy`. The recursive merge now operates exclusively on freshly-allocated maps owned by the derived context — the parent's storage is never reached.

`deepCopyMap` always returns a non-nil map (even for nil input), so a typed-nil `map[string]any` stored as a context value can't lead to a "assignment to entry in nil map" panic.

Non-map values are stored by assignment to an `any` slot. Value types (int, string, struct) are copied as usual; reference types (slices, pointers, channels, function values) remain shared with the source. ContextProvider never mutates stored values in place. `*http.Request` and `http.Request` inputs are converted to maps via `helpers.RequestToMap` on the way in, so the underlying request is not retained.

## Tests

- **`TestContextProvider_AddDataToContext_Concurrent`** — 32 goroutines × 100 iterations against a **shared enriched parent** (the pattern that used to race). Without the fix this panics with `concurrent map writes` on the first iteration; with the fix it passes cleanly under `-race -count=20`. Also asserts the parent context is unchanged after concurrent enrichment, locking in the independence contract.

- **`TestContextProvider_AddDataToContext_TypedNilParent`** — guards against a regression caught in Copilot review: a typed-nil `map[string]any` stored in the context must not panic the subsequent merge.

## Docs

- README "Thread-safe Data Management" feature bullet — restored with an accurate qualifier about deep-copying nested maps.
- README "Concurrency and thread-safety" subsection — confident positive statements, plus accurate description of which value kinds remain shared (reference types only; `*http.Request` is converted, not stored).
- `ContextProvider.AddDataToContext` godoc — same.

## Supersedes

- Closes #93.
- #126 was filed as a #101 refile for the race-test piece; closed as duplicate of #93.

## Test plan

- [x] `go test -race -count=1 ./platform/data/...` — green (new test + existing typed-nil regression test pass)
- [x] `go test -race -count=20 -run TestContextProvider_AddDataToContext_Concurrent` — no flakes
- [x] **Negative check**: reverted `contextProvider.go` to shallow-copy locally, kept the new test → panics with `concurrent map writes` on the first goroutine, confirming the test is real regression coverage
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] CI on the PR

Closes #93

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL