### PR TITLE
fix(loader): cache SHA in FromHTTP so String() no longer makes HTTP calls

### DIFF
--- a/platform/script/loader/fromHTTP.go
+++ b/platform/script/loader/fromHTTP.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	"github.com/robbyt/go-polyscript/internal/helpers"
@@ -139,6 +140,13 @@ type FromHTTP struct {
 	sourceURL *url.URL
 	options   *HTTPOptions
 	client    httpRequester
+
+	// sha holds a short (8-char) SHA-256 prefix of the response body,
+	// cached on the first successful GetReader call. String() loads it
+	// without making a network request. Nil until the first body has
+	// been buffered by cappedBody — when MaxBodySize is negative the
+	// body is streamed and the cache stays unset.
+	sha atomic.Pointer[string]
 }
 
 // NewFromHTTP creates a new HTTP loader with the given URL and default options.
@@ -308,6 +316,17 @@ func (l *FromHTTP) cappedBody(resp *http.Response) (io.ReadCloser, error) {
 	if int64(len(buf)) > limit {
 		return nil, fmt.Errorf("%w: %s exceeds %d bytes", ErrScriptTooLarge, l.url, limit)
 	}
+
+	// Cache the short SHA prefix from the first successful read so
+	// String() can include it without a network round-trip. CAS-on-nil
+	// keeps the first writer's value if multiple goroutines race here.
+	if l.sha.Load() == nil {
+		if sum, sumErr := helpers.SHA256Reader(bytes.NewReader(buf)); sumErr == nil && len(sum) >= 8 {
+			short := sum[:8]
+			l.sha.CompareAndSwap(nil, &short)
+		}
+	}
+
 	return io.NopCloser(bytes.NewReader(buf)), nil
 }
 
@@ -317,34 +336,19 @@ func (l *FromHTTP) GetSourceURL() *url.URL {
 	return l.sourceURL
 }
 
-// String returns a string representation of the HTTP loader.
-// This is useful for debugging and logging.
+// String returns a string representation of the HTTP loader, suitable
+// for debugging and logging. The returned value is cheap to compute:
+// it never performs a network request.
+//
+// The "SHA256: <prefix>" form is included only after the body has been
+// fetched at least once via [FromHTTP.GetReader] (or
+// [FromHTTP.GetReaderWithContext]) and the response was buffered through
+// [FromHTTP.cappedBody]. Until then — or when [HTTPOptions.MaxBodySize]
+// is negative (which disables buffering) — String returns the
+// no-checksum form.
 func (l *FromHTTP) String() string {
-	var chksum string
-	noChkSum := fmt.Sprintf("loader.FromHTTP{URL: %s}", l.url)
-
-	if l.sourceURL != nil {
-		reader, err := l.GetReader()
-		if err != nil {
-			return noChkSum
-		}
-		defer func() {
-			if err := reader.Close(); err != nil {
-				slog.Default().Debug("Failed to close reader in String() method", "error", err)
-			}
-		}()
-
-		chksum, err = helpers.SHA256Reader(reader)
-		if err != nil {
-			return noChkSum
-		}
-
-		chksum = chksum[:8]
+	if p := l.sha.Load(); p != nil {
+		return fmt.Sprintf("loader.FromHTTP{URL: %s, SHA256: %s}", l.url, *p)
 	}
-
-	if chksum == "" {
-		return noChkSum
-	}
-
-	return fmt.Sprintf("loader.FromHTTP{URL: %s, SHA256: %s}", l.url, chksum)
+	return fmt.Sprintf("loader.FromHTTP{URL: %s}", l.url)
 }

--- a/platform/script/loader/fromHTTP.go
+++ b/platform/script/loader/fromHTTP.go
@@ -321,7 +321,8 @@ func (l *FromHTTP) cappedBody(resp *http.Response) (io.ReadCloser, error) {
 	// String() can include it without a network round-trip. CAS-on-nil
 	// keeps the first writer's value if multiple goroutines race here.
 	if l.sha.Load() == nil {
-		if sum, sumErr := helpers.SHA256Reader(bytes.NewReader(buf)); sumErr == nil && len(sum) >= 8 {
+		sum := helpers.SHA256Bytes(buf)
+		if len(sum) >= 8 {
 			short := sum[:8]
 			l.sha.CompareAndSwap(nil, &short)
 		}

--- a/platform/script/loader/fromHTTP_test.go
+++ b/platform/script/loader/fromHTTP_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -540,7 +542,7 @@ func TestFromHTTP_GetReaderWithContext(t *testing.T) {
 func TestFromHTTP_String(t *testing.T) {
 	t.Parallel()
 
-	t.Run("successful string representation", func(t *testing.T) {
+	t.Run("string representation populates SHA after first GetReader", func(t *testing.T) {
 		// Create test server that returns content
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -554,15 +556,24 @@ func TestFromHTTP_String(t *testing.T) {
 		loader, err := NewFromHTTP(testURL)
 		require.NoError(t, err)
 
+		// Issue #96: String() no longer fetches on its own. The SHA is
+		// cached during the production GetReader path; drain a reader
+		// here to populate it.
+		r, err := loader.GetReader()
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, r)
+		require.NoError(t, r.Close())
+
 		str := loader.String()
 		require.Contains(t, str, "loader.FromHTTP{URL:")
 		require.Contains(t, str, testURL)
 		require.Contains(t, str, "SHA256:")
 	})
 
-	t.Run("string representation with network error", func(t *testing.T) {
-		// Create server that deliberately fails connections (invalid port)
-		testURL := "http://localhost:1" // This port is unlikely to be listening
+	t.Run("string representation when no read has occurred is the no-checksum form", func(t *testing.T) {
+		// Unreachable URL — String() must still return cheaply with no
+		// network round-trip.
+		testURL := "http://localhost:1" // unlikely to be listening
 
 		loader, err := NewFromHTTP(testURL)
 		require.NoError(t, err)
@@ -590,6 +601,113 @@ func TestFromHTTP_String(t *testing.T) {
 		str := loader.String()
 		require.Contains(t, str, "loader.FromHTTP{URL:")
 		require.Contains(t, str, testURL)
+		require.NotContains(t, str, "SHA256")
+	})
+}
+
+// TestFromHTTP_String_NoNetworkRoundTrip is the regression suite for
+// issue #96: String() must be cheap and side-effect-free. The cache
+// is populated only when the body has been fetched through the regular
+// GetReader path.
+func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("String before GetReader makes no HTTP request", func(t *testing.T) {
+		var hits atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("body"))
+		}))
+		defer server.Close()
+
+		loader, err := NewFromHTTP(server.URL + "/script.js")
+		require.NoError(t, err)
+
+		// Multiple String() calls — none should hit the server.
+		for range 5 {
+			str := loader.String()
+			require.Contains(t, str, "loader.FromHTTP{URL:")
+			require.NotContains(t, str, "SHA256")
+		}
+		require.Equal(t, int32(0), hits.Load(), "String() must not perform HTTP requests")
+	})
+
+	t.Run("String after GetReader returns cached SHA without re-fetching", func(t *testing.T) {
+		var hits atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			_, _ = w.Write([]byte("deterministic body"))
+		}))
+		defer server.Close()
+
+		loader, err := NewFromHTTP(server.URL + "/script.js")
+		require.NoError(t, err)
+
+		r, err := loader.GetReader()
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, r)
+		require.NoError(t, r.Close())
+		require.Equal(t, int32(1), hits.Load(), "GetReader should hit the server once")
+
+		// Multiple String() calls — still only 1 server hit.
+		for range 5 {
+			str := loader.String()
+			require.Contains(t, str, "SHA256: ")
+		}
+		require.Equal(t, int32(1), hits.Load(), "String() must not re-fetch")
+	})
+
+	t.Run("Concurrent String and GetReader is race-free", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("body"))
+		}))
+		defer server.Close()
+
+		loader, err := NewFromHTTP(server.URL + "/script.js")
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		for range 32 {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				_ = loader.String()
+			}()
+			go func() {
+				defer wg.Done()
+				r, err := loader.GetReader()
+				if err != nil {
+					return
+				}
+				_, _ = io.Copy(io.Discard, r)
+				_ = r.Close()
+			}()
+		}
+		wg.Wait()
+
+		// After the dust settles, SHA must be cached.
+		require.Contains(t, loader.String(), "SHA256: ")
+	})
+
+	t.Run("MaxBodySize=-1 streams body and leaves SHA cache empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("body"))
+		}))
+		defer server.Close()
+
+		opts := DefaultHTTPOptions().WithMaxBodySize(-1)
+		loader, err := NewFromHTTPWithOptions(server.URL+"/script.js", opts)
+		require.NoError(t, err)
+
+		r, err := loader.GetReader()
+		require.NoError(t, err)
+		_, _ = io.Copy(io.Discard, r)
+		require.NoError(t, r.Close())
+
+		// Negative cap disables buffering in cappedBody, so the SHA
+		// cache stays empty. String() falls back to no-checksum form.
+		str := loader.String()
+		require.Contains(t, str, "loader.FromHTTP{URL:")
 		require.NotContains(t, str, "SHA256")
 	})
 }

--- a/platform/script/loader/fromHTTP_test.go
+++ b/platform/script/loader/fromHTTP_test.go
@@ -561,7 +561,8 @@ func TestFromHTTP_String(t *testing.T) {
 		// here to populate it.
 		r, err := loader.GetReader()
 		require.NoError(t, err)
-		_, _ = io.Copy(io.Discard, r)
+		_, copyErr := io.Copy(io.Discard, r)
+		require.NoError(t, copyErr)
 		require.NoError(t, r.Close())
 
 		str := loader.String()
@@ -616,7 +617,8 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 		var hits atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			hits.Add(1)
-			_, _ = w.Write([]byte("body"))
+			_, writeErr := w.Write([]byte("body"))
+			assert.NoError(t, writeErr)
 		}))
 		defer server.Close()
 
@@ -636,7 +638,8 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 		var hits atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			hits.Add(1)
-			_, _ = w.Write([]byte("deterministic body"))
+			_, writeErr := w.Write([]byte("deterministic body"))
+			assert.NoError(t, writeErr)
 		}))
 		defer server.Close()
 
@@ -645,7 +648,8 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 
 		r, err := loader.GetReader()
 		require.NoError(t, err)
-		_, _ = io.Copy(io.Discard, r)
+		_, copyErr := io.Copy(io.Discard, r)
+		require.NoError(t, copyErr)
 		require.NoError(t, r.Close())
 		require.Equal(t, int32(1), hits.Load(), "GetReader should hit the server once")
 
@@ -659,7 +663,8 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 
 	t.Run("Concurrent String and GetReader is race-free", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("body"))
+			_, writeErr := w.Write([]byte("body"))
+			assert.NoError(t, writeErr)
 		}))
 		defer server.Close()
 
@@ -679,8 +684,9 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 				if err != nil {
 					return
 				}
-				_, _ = io.Copy(io.Discard, r)
-				_ = r.Close()
+				_, copyErr := io.Copy(io.Discard, r)
+				assert.NoError(t, copyErr)
+				assert.NoError(t, r.Close())
 			}()
 		}
 		wg.Wait()
@@ -691,7 +697,8 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 
 	t.Run("MaxBodySize=-1 streams body and leaves SHA cache empty", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte("body"))
+			_, writeErr := w.Write([]byte("body"))
+			assert.NoError(t, writeErr)
 		}))
 		defer server.Close()
 
@@ -701,7 +708,8 @@ func TestFromHTTP_String_NoNetworkRoundTrip(t *testing.T) {
 
 		r, err := loader.GetReader()
 		require.NoError(t, err)
-		_, _ = io.Copy(io.Discard, r)
+		_, copyErr := io.Copy(io.Discard, r)
+		require.NoError(t, copyErr)
 		require.NoError(t, r.Close())
 
 		// Negative cap disables buffering in cappedBody, so the SHA


### PR DESCRIPTION
## Summary

`(*FromHTTP).String()` used to call `l.GetReader()` on every invocation to compute a SHA-256 prefix — a network round-trip from a Stringer. Every `%v` / `%s` format verb on a `*FromHTTP` became an HTTP request, and the result was non-deterministic on flaky networks (silently degraded to the no-checksum form on read failure).

Cache the SHA in the loader struct after the first successful read; have `String()` do a cheap atomic load.

## Mechanism

- New `sha atomic.Pointer[string]` field on `FromHTTP`. `atomic.Pointer` is goroutine-safe (the loader is shared via the `Loader` interface) and `CompareAndSwap`-on-nil keeps the first writer's value if multiple goroutines race.
- Populated in `cappedBody` after `io.ReadAll` succeeds — the capped path already has the full buffer in memory, so computing the SHA over it is essentially free.
- When `MaxBodySize < 0` the body is streamed unbuffered, so the cache stays empty and `String()` falls back to the no-checksum form. Documented as a known limitation in the `String()` godoc.
- Rewritten `String()`: cheap atomic load. No network, no deferred close, no per-call SHA recomputation.

## Tests

- `TestFromHTTP_String` / `"string representation populates SHA after first GetReader"` — updated to drain a reader before asserting the `SHA256:` form (the old test relied on `String()` auto-fetching).
- New `TestFromHTTP_String_NoNetworkRoundTrip` with four subtests:
  - **String before GetReader** makes zero HTTP hits (httptest counter asserts 0).
  - **String after one GetReader** returns cached SHA, and 5 more `String()` calls produce no additional hits (counter stays at 1).
  - **Concurrent String + GetReader** passes under `-race` (32+32 goroutines).
  - **MaxBodySize=-1** leaves the cache empty (documented limitation).

## Test plan

- [x] `go test -race -count=1 ./platform/script/loader/...` — green
- [x] `go test -race -count=20 -run TestFromHTTP_String` — no flakes
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet ./...` — clean
- [ ] CI on the PR

Closes #96

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_