### PR TITLE
test(httpauth): drop time.Sleep+1ns timeout dance in cancellation tests

### DIFF
--- a/platform/script/loader/httpauth/basic_test.go
+++ b/platform/script/loader/httpauth/basic_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -94,9 +93,8 @@ func TestBasicAuth(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
-		time.Sleep(5 * time.Millisecond) // Ensure the timeout occurs
-		defer cancel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
 
 		auth := NewBasicAuth(username, password)
 		require.Equal(t, "Basic", auth.Name())

--- a/platform/script/loader/httpauth/header_test.go
+++ b/platform/script/loader/httpauth/header_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -112,9 +111,8 @@ func TestHeaderAuth(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
-		time.Sleep(5 * time.Millisecond) // Ensure the timeout occurs
-		defer cancel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
 
 		err = auth.AuthenticateWithContext(ctx, req)
 		require.Error(t, err)

--- a/platform/script/loader/httpauth/noauth_test.go
+++ b/platform/script/loader/httpauth/noauth_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -56,9 +55,8 @@ func TestNoAuth(t *testing.T) {
 		req, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(t.Context(), 1*time.Nanosecond)
-		time.Sleep(5 * time.Millisecond) // Ensure the timeout occurs
-		defer cancel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
 
 		err = auth.AuthenticateWithContext(ctx, req)
 		require.Error(t, err)


### PR DESCRIPTION
Three subtests used `context.WithTimeout(1*time.Nanosecond)` followed by
`time.Sleep(5*time.Millisecond)` to "ensure the timeout occurs" before
calling AuthenticateWithContext and asserting an error. The same code
path (authenticator.go:44-45 returns ctx.Err() when ctx.Done() closes)
is exercised more directly by an already-cancelled context.

Replace each with `context.WithCancel`+immediate `cancel()`. Drops the
`time` import from all three files. No magic timing, no 5ms test cost.