### PR TITLE
test(starlark): use testing/synctest for TestEval_NoGoroutineLeak

### DIFF
--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 	"net/http/httptest"
 	"os"
-	"runtime"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/robbyt/go-polyscript/engines/starlark/compiler"
@@ -219,33 +219,27 @@ invalid_func()
 	})
 }
 
-// TestEval_NoGoroutineLeak verifies that Eval() with a non-cancellable context does not leak goroutines.
-// Not parallelised on purpose — runtime.NumGoroutine() reads the process-wide goroutine count, so
-// concurrent tests would perturb the baseline and make the assertion flaky.
+// TestEval_NoGoroutineLeak verifies that Eval() with a non-cancellable context does not leak
+// goroutines. synctest.Run only returns once every goroutine spawned inside the bubble has
+// exited; a stray goroutine blocked on <-ctx.Done() (the scenario PR #81 fixed by switching to
+// context.AfterFunc) would be reported as a leak with a clear diagnostic.
 func TestEval_NoGoroutineLeak(t *testing.T) {
+	t.Parallel()
+
 	scriptContent := `_ = 1 + 1`
 	_, evaluator := evalBuilder(t, scriptContent)
 
-	// Record baseline goroutine count
-	runtime.GC()
-	before := runtime.NumGoroutine()
-
-	// Use context.Background() so ctx.Done() is nil — this is the exact scenario
-	// where a bare goroutine waiting on <-ctx.Done() would block forever and leak.
-	// t.Context() would defeat the test by giving a cancellable context.
-	for range 100 {
-		//nolint:usetesting // intentional — see comment above
-		ctx := context.WithValue(context.Background(), constants.EvalData, map[string]any{})
-		_, err := evaluator.Eval(ctx)
-		require.NoError(t, err)
-	}
-
-	// Allow goroutines to settle
-	runtime.GC()
-	after := runtime.NumGoroutine()
-
-	growth := after - before
-	require.Less(t, growth, 5, "goroutine count grew by %d after 100 Eval() calls; suspected leak", growth)
+	synctest.Test(t, func(t *testing.T) {
+		// Use context.Background() so ctx.Done() is nil — this is the exact scenario where a
+		// bare goroutine waiting on <-ctx.Done() would block forever and leak. t.Context()
+		// would defeat the test by giving a cancellable context.
+		for range 100 {
+			//nolint:usetesting // intentional — see comment above
+			ctx := context.WithValue(context.Background(), constants.EvalData, map[string]any{})
+			_, err := evaluator.Eval(ctx)
+			require.NoError(t, err)
+		}
+	})
 }
 
 // TestEvaluator_AddDataToContext tests the AddDataToContext method with various scenarios

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -220,7 +220,7 @@ invalid_func()
 }
 
 // TestEval_NoGoroutineLeak verifies that Eval() with a non-cancellable context does not leak
-// goroutines. synctest.Run only returns once every goroutine spawned inside the bubble has
+// goroutines. synctest.Test only returns once every goroutine spawned inside the bubble has
 // exited; a stray goroutine blocked on <-ctx.Done() (the scenario PR #81 fixed by switching to
 // context.AfterFunc) would be reported as a leak with a clear diagnostic.
 func TestEval_NoGoroutineLeak(t *testing.T) {


### PR DESCRIPTION
## Summary

`TestEval_NoGoroutineLeak` previously sampled `runtime.NumGoroutine()` before/after 100 `Eval()` calls and asserted `growth < 5`. Process-wide counter, brittle, couldn't `t.Parallel`, and the failure mode was a fuzzy count rather than a pointer at the leaker.

`synctest.Test` runs the body in a bubble that only exits once every goroutine spawned inside has returned. A stray goroutine blocked on `<-ctx.Done()` (the leak PR #81 fixed by switching to `context.AfterFunc`) is reported with a clear `chan receive (nil chan) (durable), synctest bubble` diagnostic pointing directly at the offending stack.

Drops `runtime` import, re-enables `t.Parallel`.

## Negative-check verification

Temporarily reverted `evaluator.go:106-109` to a raw `go func(){ <-ctx.Done(); thread.Cancel(...) }()` and confirmed synctest fails the test with a precise leak diagnostic. Restored before commit.

## Test plan

- [x] `go test -race -count=20 -run TestEval_NoGoroutineLeak ./engines/starlark/evaluator/...` — clean
- [x] `go test -race -count=1 ./...` — full suite clean
- [x] `go vet ./...` — clean
- [x] Negative check (revert AfterFunc → raw goroutine) produces a clear synctest leak report

Closes #130

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_