### PR TITLE
feat(starlark): expose *starlark.EvalError via rich Error type

### DIFF
--- a/engines/starlark/evaluator/error.go
+++ b/engines/starlark/evaluator/error.go
@@ -1,0 +1,45 @@
+package evaluator
+
+import (
+	"errors"
+
+	starlarkLib "go.starlark.net/starlark"
+)
+
+// Error is returned from (*Evaluator).Eval for Starlark execution failures
+// — script-side fail() calls, runtime exceptions, and auto-called callable
+// failures. It implements error and exposes the underlying
+// *starlark.EvalError via Unwrap() and via the GetErrorDetails helper.
+//
+// Callers using `if err != nil` need no changes. Callers wanting access to
+// the call stack or backtrace can either type-assert with errors.As or
+// call GetErrorDetails(err).
+type Error struct {
+	// Msg is the human-readable wrapper message.
+	Msg string
+
+	// EvalErr is the raw Starlark error, or nil if the failure didn't
+	// originate inside Starlark script execution.
+	EvalErr *starlarkLib.EvalError
+}
+
+func (e *Error) Error() string { return e.Msg }
+
+func (e *Error) Unwrap() error {
+	if e.EvalErr == nil {
+		return nil
+	}
+	return e.EvalErr
+}
+
+// GetErrorDetails returns the underlying *starlark.EvalError from a
+// Starlark evaluator error, or nil if err isn't one of ours or carries no
+// detail. Convenience for callers who prefer not to declare a typed target
+// for errors.As.
+func GetErrorDetails(err error) *starlarkLib.EvalError {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.EvalErr
+	}
+	return nil
+}

--- a/engines/starlark/evaluator/evaluator.go
+++ b/engines/starlark/evaluator/evaluator.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -113,7 +114,12 @@ func (be *Evaluator) exec(
 	execTime := time.Since(startTime)
 
 	if err != nil {
-		return nil, fmt.Errorf("starlark execution error: %w", err)
+		var evalErr *starlarkLib.EvalError
+		errors.As(err, &evalErr)
+		return nil, &Error{
+			Msg:     fmt.Sprintf("starlark execution error: %s", err),
+			EvalErr: evalErr,
+		}
 	}
 
 	// Get the main value from globals
@@ -202,7 +208,12 @@ func (be *Evaluator) Eval(ctx context.Context) (platform.EvaluatorResponse, erro
 		thread := &starlarkLib.Thread{Name: "func"}
 		val, err := starlarkLib.Call(thread, callable, nil, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error calling function: %w", err)
+			var evalErr *starlarkLib.EvalError
+			errors.As(err, &evalErr)
+			return nil, &Error{
+				Msg:     fmt.Sprintf("error calling function: %s", err),
+				EvalErr: evalErr,
+			}
 		}
 		// "Freeze" the value to prevent any further modifications
 		val.Freeze()

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -391,3 +391,89 @@ result = spin()
 		t.Fatal("Eval did not return within 2s after cancel; cancellation unresponsive")
 	}
 }
+
+// TestEval_ErrorTypeExposesStarlarkDetails verifies that errors returned from
+// Eval expose the underlying *starlark.EvalError via errors.As and via the
+// GetErrorDetails helper, including through additional fmt.Errorf wrapping.
+func TestEval_ErrorTypeExposesStarlarkDetails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fail() in script surfaces EvalError", func(t *testing.T) {
+		t.Parallel()
+
+		const scriptContent = `fail("user reason")`
+		_, eval := evalBuilder(t, scriptContent)
+
+		_, err := eval.Eval(t.Context())
+		require.Error(t, err)
+
+		var evalErrWrap *Error
+		require.True(t, errors.As(err, &evalErrWrap), "errors.As should recover *evaluator.Error")
+		require.NotNil(t, evalErrWrap.EvalErr, "EvalErr should be populated for fail()")
+		require.Contains(t, evalErrWrap.EvalErr.Msg, "user reason")
+		require.NotEmpty(t, evalErrWrap.EvalErr.Backtrace(), "Backtrace should be non-empty")
+
+		details := GetErrorDetails(err)
+		require.NotNil(t, details)
+		require.Same(t, evalErrWrap.EvalErr, details, "GetErrorDetails returns the same *starlark.EvalError")
+	})
+
+	t.Run("further wrapping preserves recovery", func(t *testing.T) {
+		t.Parallel()
+
+		const scriptContent = `fail("nested")`
+		_, eval := evalBuilder(t, scriptContent)
+
+		_, err := eval.Eval(t.Context())
+		require.Error(t, err)
+
+		wrapped := fmt.Errorf("upstream: %w", err)
+
+		var evalErrWrap *Error
+		require.True(t, errors.As(wrapped, &evalErrWrap), "errors.As works through extra wrapping")
+		require.NotNil(t, evalErrWrap.EvalErr)
+		require.Contains(t, evalErrWrap.EvalErr.Msg, "nested")
+
+		require.NotNil(t, GetErrorDetails(wrapped))
+	})
+
+	t.Run("auto-call failure surfaces EvalError", func(t *testing.T) {
+		t.Parallel()
+
+		// Script's last value is a callable; auto-call invokes it; the call
+		// raises via fail() and the evaluator wraps it as *Error.
+		const scriptContent = `
+def boom():
+    fail("from callable")
+
+_ = boom
+`
+		_, eval := evalBuilder(t, scriptContent)
+
+		_, err := eval.Eval(t.Context())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error calling function")
+
+		details := GetErrorDetails(err)
+		require.NotNil(t, details)
+		require.Contains(t, details.Msg, "from callable")
+	})
+
+	t.Run("non-Starlark failure leaves EvalErr nil", func(t *testing.T) {
+		t.Parallel()
+
+		// Hitting the "executable unit is nil" path returns a *fmt.Errorf
+		// without ever calling into Starlark — GetErrorDetails should return
+		// nil and a bare err != nil check still works.
+		handler := slog.NewTextHandler(os.Stdout, nil)
+		eval := New(handler, nil)
+
+		_, err := eval.Eval(t.Context())
+		require.Error(t, err)
+
+		require.Nil(t, GetErrorDetails(err))
+
+		var evalErrWrap *Error
+		require.False(t, errors.As(err, &evalErrWrap), "errors.As should not match for non-Starlark errors")
+	})
+}

--- a/engines/starlark/evaluator/evaluator_test.go
+++ b/engines/starlark/evaluator/evaluator_test.go
@@ -408,7 +408,7 @@ func TestEval_ErrorTypeExposesStarlarkDetails(t *testing.T) {
 		require.Error(t, err)
 
 		var evalErrWrap *Error
-		require.True(t, errors.As(err, &evalErrWrap), "errors.As should recover *evaluator.Error")
+		require.ErrorAs(t, err, &evalErrWrap)
 		require.NotNil(t, evalErrWrap.EvalErr, "EvalErr should be populated for fail()")
 		require.Contains(t, evalErrWrap.EvalErr.Msg, "user reason")
 		require.NotEmpty(t, evalErrWrap.EvalErr.Backtrace(), "Backtrace should be non-empty")
@@ -430,7 +430,7 @@ func TestEval_ErrorTypeExposesStarlarkDetails(t *testing.T) {
 		wrapped := fmt.Errorf("upstream: %w", err)
 
 		var evalErrWrap *Error
-		require.True(t, errors.As(wrapped, &evalErrWrap), "errors.As works through extra wrapping")
+		require.ErrorAs(t, wrapped, &evalErrWrap)
 		require.NotNil(t, evalErrWrap.EvalErr)
 		require.Contains(t, evalErrWrap.EvalErr.Msg, "nested")
 
@@ -474,6 +474,6 @@ _ = boom
 		require.Nil(t, GetErrorDetails(err))
 
 		var evalErrWrap *Error
-		require.False(t, errors.As(err, &evalErrWrap), "errors.As should not match for non-Starlark errors")
+		require.NotErrorAs(t, err, &evalErrWrap)
 	})
 }


### PR DESCRIPTION
## Summary

Both Starlark `Eval` failure paths (`prog.Init` and the auto-call of a callable top-level value) previously returned `fmt.Errorf`-wrapped strings that stringified away the `*starlark.EvalError` details — message, call stack, backtrace position. Callers had no idiomatic way to recover that info.

Introduces `evaluator.Error`: implements `error`, carries the underlying `*starlark.EvalError`, and `Unwrap()`s to it so `errors.As` recovers the typed Starlark error. `GetErrorDetails(err)` provides a convenience accessor for callers who'd rather not declare a typed target. Bare `if err != nil` callers see no behavior change.

Risor's `(result, err)` three-state stays as-is in this PR — follow-up brings Risor onto the same pattern.

## Usage

```go
_, err := eval.Eval(ctx)
if err != nil {
    // Option A: errors.As with a typed target.
    var scriptErr *evaluator.Error
    if errors.As(err, &scriptErr) && scriptErr.EvalErr != nil {
        log.Println(scriptErr.EvalErr.Backtrace())
    }

    // Option B: convenience helper.
    if details := evaluator.GetErrorDetails(err); details != nil {
        log.Println(details.Backtrace())
    }
}
```

## Files

- New: `engines/starlark/evaluator/error.go` — `Error` type + `GetErrorDetails` helper
- Modified: `engines/starlark/evaluator/evaluator.go` — both failure paths return `*Error`
- Modified: `engines/starlark/evaluator/evaluator_test.go` — `TestEval_ErrorTypeExposesStarlarkDetails`

## Test plan

- [x] `go test -race -count=20 -run TestEval_ErrorTypeExposesStarlarkDetails ./engines/starlark/evaluator/...`
- [x] `go test -race -count=1 ./...` — full suite passes
- [x] `go vet ./...` clean
- [x] `errors.As` recovery through further `fmt.Errorf("...: %w", err)` wrapping
- [x] Non-Starlark error path (nil executable unit) — `GetErrorDetails` returns nil, no false positives

Refs #97 (Risor follow-up still pending — left open).

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_