### PR TITLE
feat(risor): rich Error type; drop (result, err) three-state shape

### DIFF
--- a/engines/risor/evaluator/error.go
+++ b/engines/risor/evaluator/error.go
@@ -5,9 +5,13 @@ import (
 )
 
 // Error is returned from (*Evaluator).Eval for Risor execution failures —
-// VM exec errors (compile/runtime crash) and script-side error/function
-// returns. It implements error and exposes the diagnostic Inspect()
-// output of the script-side error/function object via ScriptResult.
+// VM runtime errors (e.g. type mismatches, divide-by-zero, cancellation)
+// and script-side error/function returns. Compile-time failures occur in
+// the compiler package before an Evaluator is constructed and are not
+// surfaced through this type.
+//
+// It implements error and exposes the diagnostic Inspect() output of the
+// script-side error/function object via ScriptResult.
 //
 // Callers using `if err != nil` need no changes. Callers wanting the
 // script-side diagnostic can either type-assert with errors.As or call

--- a/engines/risor/evaluator/error.go
+++ b/engines/risor/evaluator/error.go
@@ -1,0 +1,44 @@
+package evaluator
+
+import (
+	"errors"
+)
+
+// Error is returned from (*Evaluator).Eval for Risor execution failures —
+// VM exec errors (compile/runtime crash) and script-side error/function
+// returns. It implements error and exposes the diagnostic Inspect()
+// output of the script-side error/function object via ScriptResult.
+//
+// Callers using `if err != nil` need no changes. Callers wanting the
+// script-side diagnostic can either type-assert with errors.As or call
+// GetErrorDetails(err).
+type Error struct {
+	// Msg is the human-readable wrapper message.
+	Msg string
+
+	// ScriptResult is the failing object's Inspect() output when the
+	// script returned an error or function value. Empty for VM exec
+	// failures and non-script failures.
+	ScriptResult string
+
+	// Cause is the wrapped VM/exec error, if any. nil for script-side
+	// error/function returns.
+	Cause error
+}
+
+func (e *Error) Error() string { return e.Msg }
+
+func (e *Error) Unwrap() error { return e.Cause }
+
+// GetErrorDetails returns the script-side diagnostic (the Inspect()
+// output of the returned error or function object) from a Risor
+// evaluator error, or "" if err isn't one of ours or carries no script
+// detail. Convenience for callers who prefer not to declare a typed
+// target for errors.As.
+func GetErrorDetails(err error) string {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.ScriptResult
+	}
+	return ""
+}

--- a/engines/risor/evaluator/evaluator.go
+++ b/engines/risor/evaluator/evaluator.go
@@ -133,7 +133,10 @@ func (be *Evaluator) Eval(ctx context.Context) (platform.EvaluatorResponse, erro
 	// 4. Execute the program
 	result, err := be.exec(ctx, risorByteCode, runtimeEnv)
 	if err != nil {
-		return nil, fmt.Errorf("exec error: %w", err)
+		return nil, &Error{
+			Msg:   fmt.Sprintf("exec error: %s", err),
+			Cause: err,
+		}
 	}
 	logger.DebugContext(ctx, "exec complete", "result", result)
 
@@ -147,9 +150,15 @@ func (be *Evaluator) Eval(ctx context.Context) (platform.EvaluatorResponse, erro
 
 	switch result.Object.Type() {
 	case "error":
-		return result, fmt.Errorf("error returned from script: %s", result.Inspect())
+		return nil, &Error{
+			Msg:          fmt.Sprintf("error returned from script: %s", result.Inspect()),
+			ScriptResult: result.Inspect(),
+		}
 	case "function":
-		return result, fmt.Errorf("function object returned from script: %s", result.Inspect())
+		return nil, &Error{
+			Msg:          fmt.Sprintf("function object returned from script: %s", result.Inspect()),
+			ScriptResult: result.Inspect(),
+		}
 	}
 
 	return result, nil

--- a/engines/risor/evaluator/evaluator_test.go
+++ b/engines/risor/evaluator/evaluator_test.go
@@ -619,3 +619,96 @@ range(1000000000).each(x => x)
 		t.Fatal("Eval did not return within 2s after cancel; cancellation unresponsive")
 	}
 }
+
+// TestEval_ErrorTypeExposesRisorDetails verifies that errors returned from
+// Eval expose the script-side diagnostic (Inspect() output of the error/function
+// object) via errors.As and via the GetErrorDetails helper, and that the
+// three-state (result, err) shape has been retired in favor of (nil, err).
+func TestEval_ErrorTypeExposesRisorDetails(t *testing.T) {
+	t.Parallel()
+
+	buildEval := func(t *testing.T, script string) *Evaluator {
+		t.Helper()
+		handler := slog.NewTextHandler(io.Discard, nil)
+		ld, err := loader.NewFromString(script)
+		require.NoError(t, err)
+		ctxProvider := data.NewContextProvider(constants.EvalData)
+		exe, err := createTestExecutable(handler, ld, []string{constants.Ctx}, ctxProvider)
+		require.NoError(t, err)
+		eval := New(handler, exe)
+		require.NotNil(t, eval)
+		return eval
+	}
+
+	t.Run("script returns error surfaces diagnostic", func(t *testing.T) {
+		t.Parallel()
+
+		eval := buildEval(t, `error("user reason")`)
+		ctx := context.WithValue(t.Context(), constants.EvalData, map[string]any{})
+
+		result, err := eval.Eval(ctx)
+		require.Error(t, err)
+		require.Nil(t, result, "result should be nil — three-state shape retired")
+
+		var rErr *Error
+		require.ErrorAs(t, err, &rErr)
+		require.Contains(t, rErr.ScriptResult, "user reason")
+		require.Contains(t, GetErrorDetails(err), "user reason")
+	})
+
+	t.Run("script returns function surfaces diagnostic", func(t *testing.T) {
+		t.Parallel()
+
+		eval := buildEval(t, `x => x + 1`)
+		ctx := context.WithValue(t.Context(), constants.EvalData, map[string]any{})
+
+		result, err := eval.Eval(ctx)
+		require.Error(t, err)
+		require.Nil(t, result)
+
+		var rErr *Error
+		require.ErrorAs(t, err, &rErr)
+		require.NotEmpty(t, rErr.ScriptResult)
+		require.Contains(t, err.Error(), "function object returned from script")
+	})
+
+	t.Run("further wrapping preserves recovery", func(t *testing.T) {
+		t.Parallel()
+
+		eval := buildEval(t, `error("nested")`)
+		ctx := context.WithValue(t.Context(), constants.EvalData, map[string]any{})
+
+		_, err := eval.Eval(ctx)
+		require.Error(t, err)
+
+		wrapped := fmt.Errorf("upstream: %w", err)
+
+		var rErr *Error
+		require.ErrorAs(t, wrapped, &rErr)
+		require.Contains(t, rErr.ScriptResult, "nested")
+		require.Contains(t, GetErrorDetails(wrapped), "nested")
+	})
+
+	t.Run("non-Risor failure leaves ScriptResult empty", func(t *testing.T) {
+		t.Parallel()
+
+		// Hitting the "executable unit is nil" path returns a *fmt.Errorf
+		// without ever calling into the Risor VM — GetErrorDetails should
+		// return "" and ErrorAs against *Error should not match.
+		handler := slog.NewTextHandler(os.Stdout, nil)
+		eval := &Evaluator{
+			ctxKey:     constants.Ctx,
+			execUnit:   nil,
+			logHandler: handler,
+			logger:     slog.New(handler),
+		}
+
+		_, err := eval.Eval(t.Context())
+		require.Error(t, err)
+
+		require.Empty(t, GetErrorDetails(err))
+
+		var rErr *Error
+		require.NotErrorAs(t, err, &rErr)
+	})
+}

--- a/engines/risor/evaluator/evaluator_test.go
+++ b/engines/risor/evaluator/evaluator_test.go
@@ -689,6 +689,30 @@ func TestEval_ErrorTypeExposesRisorDetails(t *testing.T) {
 		require.Contains(t, GetErrorDetails(wrapped), "nested")
 	})
 
+	t.Run("VM exec failure populates Cause, leaves ScriptResult empty", func(t *testing.T) {
+		t.Parallel()
+
+		// Already-cancelled context drives the VM through be.exec and out
+		// the err != nil branch deterministically — no reliance on
+		// runtime-error script shapes.
+		eval := buildEval(t, `range(1000000).each(x => x)`)
+		ctx, cancel := context.WithCancel(t.Context())
+		ctx = context.WithValue(ctx, constants.EvalData, map[string]any{})
+		cancel()
+
+		result, err := eval.Eval(ctx)
+		require.Error(t, err)
+		require.Nil(t, result)
+
+		var rErr *Error
+		require.ErrorAs(t, err, &rErr)
+		require.Contains(t, rErr.Msg, "exec error")
+		require.Empty(t, rErr.ScriptResult, "VM exec failure should not carry ScriptResult")
+		require.Error(t, rErr.Cause, "Cause should expose the underlying VM error via Unwrap")
+		// Cause should be unwrappable to the original ctx cancellation.
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
 	t.Run("non-Risor failure leaves ScriptResult empty", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

Risor's `Eval` returned `(result, non-nil err)` when the script's top-level value was an `error` or `function` object (`evaluator.go:148-153`) — violating the idiomatic Go contract that callers should ignore `result` on `err != nil`. The diagnostic `Inspect()` text was stringified into the error message and otherwise unreachable.

Introduces `evaluator.Error` mirroring the Starlark `Error` pattern from PR #134: implements `error`, carries the script-side `Inspect()` output as `ScriptResult`, and `Unwrap()`s to the underlying VM cause for exec failures. `GetErrorDetails(err)` is a convenience accessor for the `ScriptResult`.

Both error paths now return `(nil, *Error)`:
- exec failures wrap the VM error in `Cause`
- script-side `error`/`function` returns surface their `Inspect()` output in `ScriptResult`

Function-case alignment with Starlark's call-the-function behavior is intentionally left out — distinct semantic change, file separately if desired.

## Behavior change

This is a **breaking change** to the Risor evaluator's error contract. Previously:

```go
result, err := eval.Eval(ctx)
// err != nil AND result != nil when script returned error/function
```

Now:

```go
result, err := eval.Eval(ctx)
// err != nil => result == nil, idiomatic
if details := evaluator.GetErrorDetails(err); details != "" {
    log.Println("script-side diagnostic:", details)
}
```

The repo is pre-v1 and the [README explicitly notes](https://github.com/robbyt/go-polyscript#status) that backwards compatibility is not a goal until v1. No existing repo callers relied on reading `result` after `err != nil` (verified via grep).

## Files

- New: `engines/risor/evaluator/error.go` — `Error` type + `GetErrorDetails` helper
- Modified: `engines/risor/evaluator/evaluator.go` — three error paths return `*Error` instead of `fmt.Errorf` / three-state
- Modified: `engines/risor/evaluator/evaluator_test.go` — `TestEval_ErrorTypeExposesRisorDetails`

## Test plan

- [x] `go test -race -count=20 -run TestEval_ErrorTypeExposesRisorDetails ./engines/risor/evaluator/...`
- [x] `go test -race -count=1 ./...` — full suite clean
- [x] `go vet ./...` — clean
- [x] `go mod tidy --diff` — clean
- [x] `errors.As` works through additional wrapping (`fmt.Errorf("...: %w", err)`)
- [x] Non-Risor failure path (nil executable unit) — `GetErrorDetails` returns ""; `errors.As` against `*Error` returns false

Closes #97

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_