### PR TITLE
Add error path testing for Compiler.Compile()

### DIFF
--- a/engines/extism/compiler/compiler.go
+++ b/engines/extism/compiler/compiler.go
@@ -7,9 +7,14 @@ import (
 	"log/slog"
 
 	extismSDK "github.com/extism/go-sdk"
+	"github.com/robbyt/go-polyscript/engines/extism/adapters"
 	"github.com/robbyt/go-polyscript/engines/extism/compiler/internal/compile"
 	"github.com/robbyt/go-polyscript/platform/script"
 )
+
+// compileFunc is the signature for compiling raw WASM bytes into a CompiledPlugin.
+// Defaulted to compile.CompileBytes; overridable in tests to drive failure paths.
+type compileFunc func(ctx context.Context, wasmBytes []byte, opts *compile.Settings) (adapters.CompiledPlugin, error)
 
 // Compiler implements the script.Compiler interface for WASM modules
 type Compiler struct {
@@ -18,6 +23,7 @@ type Compiler struct {
 	options        *compile.Settings
 	logHandler     slog.Handler
 	logger         *slog.Logger
+	compileFn      compileFunc
 }
 
 // New creates a new Extism WASM Compiler instance with the provided options.
@@ -75,8 +81,8 @@ func (c *Compiler) Compile(scriptReader io.ReadCloser) (script.ExecutableContent
 
 	logger.Debug("Starting WASM compilation", "scriptLength", len(scriptBytes))
 
-	// Compile the WASM module using the CompileBytes function from the internal compile package
-	plugin, err := compile.CompileBytes(c.ctx, scriptBytes, c.options)
+	// Compile the WASM module using the configured compile function (defaults to compile.CompileBytes)
+	plugin, err := c.compileFn(c.ctx, scriptBytes, c.options)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrValidationFailed, err)
 	}
@@ -106,11 +112,10 @@ func (c *Compiler) Compile(scriptReader io.ReadCloser) (script.ExecutableContent
 		)
 	}
 
-	// Create executable with the compiled plugin
+	// Create executable with the compiled plugin. Inputs are guaranteed non-empty
+	// by the checks above (scriptBytes, plugin) and validate() (funcName), so
+	// NewExecutable cannot return nil here.
 	executable := NewExecutable(scriptBytes, plugin, funcName)
-	if executable == nil {
-		return nil, ErrExecCreationFailed
-	}
 
 	logger.Debug("WASM compilation completed")
 	return executable, nil

--- a/engines/extism/compiler/compiler_test.go
+++ b/engines/extism/compiler/compiler_test.go
@@ -1,13 +1,18 @@
 package compiler
 
 import (
+	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
 
 	extismSDK "github.com/extism/go-sdk"
+	"github.com/robbyt/go-polyscript/engines/extism/adapters"
+	"github.com/robbyt/go-polyscript/engines/extism/compiler/internal/compile"
 	"github.com/robbyt/go-polyscript/engines/extism/wasmdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -290,4 +295,169 @@ func TestCompiler_Compile(t *testing.T) {
 			reader.AssertExpectations(t)
 		})
 	})
+}
+
+// TestCompiler_Compile_Branches exercises the Compile() error paths that are not
+// reachable through the real Extism SDK with a valid module: io.ReadAll failure,
+// reader Close failure, compile-yields-nil-plugin, plugin.Instance failure, and
+// instance.Close-on-defer failure. Uses the unexported compileFn seam.
+func TestCompiler_Compile_Branches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("io.ReadAll fails", func(t *testing.T) {
+		t.Parallel()
+		comp := createTestCompiler(t, "main")
+		reader := &errReader{readErr: errors.New("read kaboom")}
+
+		execContent, err := comp.Compile(reader)
+		require.Error(t, err)
+		require.Nil(t, execContent)
+		require.ErrorContains(t, err, "failed to read script")
+		require.ErrorContains(t, err, "read kaboom")
+	})
+
+	t.Run("scriptReader.Close fails", func(t *testing.T) {
+		t.Parallel()
+		comp := createTestCompiler(t, "main")
+		// Read succeeds (returns EOF on first Read with empty buffer is fine for
+		// io.ReadAll, but we want non-empty bytes so Close error is the only failure).
+		reader := &readCloseErr{
+			buf:      bytes.NewReader([]byte("anything")),
+			closeErr: errors.New("close kaboom"),
+		}
+
+		execContent, err := comp.Compile(reader)
+		require.Error(t, err)
+		require.Nil(t, execContent)
+		require.ErrorContains(t, err, "failed to close reader")
+		require.ErrorContains(t, err, "close kaboom")
+	})
+
+	t.Run("compileFn returns nil plugin without error", func(t *testing.T) {
+		t.Parallel()
+		comp := createTestCompiler(t, "main")
+		comp.compileFn = func(
+			ctx context.Context,
+			wasmBytes []byte,
+			opts *compile.Settings,
+		) (adapters.CompiledPlugin, error) {
+			return nil, nil
+		}
+
+		reader := newMockScriptReaderCloser([]byte("any-bytes"))
+		reader.On("Close").Return(nil)
+
+		execContent, err := comp.Compile(reader)
+		require.Error(t, err)
+		require.Nil(t, execContent)
+		require.ErrorIs(t, err, ErrBytecodeNil)
+		reader.AssertExpectations(t)
+	})
+
+	t.Run("plugin.Instance fails", func(t *testing.T) {
+		t.Parallel()
+		comp := createTestCompiler(t, "main")
+
+		plugin := &mockCompiledPlugin{}
+		plugin.On("Instance", mock.Anything, mock.Anything).
+			Return(nil, errors.New("instance kaboom"))
+
+		comp.compileFn = func(
+			ctx context.Context,
+			wasmBytes []byte,
+			opts *compile.Settings,
+		) (adapters.CompiledPlugin, error) {
+			return plugin, nil
+		}
+
+		reader := newMockScriptReaderCloser([]byte("any-bytes"))
+		reader.On("Close").Return(nil)
+
+		execContent, err := comp.Compile(reader)
+		require.Error(t, err)
+		require.Nil(t, execContent)
+		require.ErrorIs(t, err, ErrValidationFailed)
+		require.ErrorContains(t, err, "failed to create test instance")
+		require.ErrorContains(t, err, "instance kaboom")
+		plugin.AssertExpectations(t)
+		reader.AssertExpectations(t)
+	})
+
+	t.Run("instance.Close error is logged, not returned", func(t *testing.T) {
+		t.Parallel()
+		comp := createTestCompiler(t, "main")
+
+		instance := &mockPluginInstance{}
+		instance.On("FunctionExists", "main").Return(true)
+		instance.On("Close", mock.Anything).Return(errors.New("close kaboom"))
+
+		plugin := &mockCompiledPlugin{}
+		plugin.On("Instance", mock.Anything, mock.Anything).Return(instance, nil)
+
+		comp.compileFn = func(
+			ctx context.Context,
+			wasmBytes []byte,
+			opts *compile.Settings,
+		) (adapters.CompiledPlugin, error) {
+			return plugin, nil
+		}
+
+		reader := newMockScriptReaderCloser([]byte("any-bytes"))
+		reader.On("Close").Return(nil)
+
+		execContent, err := comp.Compile(reader)
+		require.NoError(t, err, "instance.Close error must not propagate")
+		require.NotNil(t, execContent)
+		plugin.AssertExpectations(t)
+		instance.AssertExpectations(t)
+		reader.AssertExpectations(t)
+	})
+
+	t.Run("FunctionExists returns false", func(t *testing.T) {
+		t.Parallel()
+		comp := createTestCompiler(t, "no_such_fn")
+
+		instance := &mockPluginInstance{}
+		instance.On("FunctionExists", "no_such_fn").Return(false)
+		instance.On("Close", mock.Anything).Return(nil)
+
+		plugin := &mockCompiledPlugin{}
+		plugin.On("Instance", mock.Anything, mock.Anything).Return(instance, nil)
+
+		comp.compileFn = func(
+			ctx context.Context,
+			wasmBytes []byte,
+			opts *compile.Settings,
+		) (adapters.CompiledPlugin, error) {
+			return plugin, nil
+		}
+
+		reader := newMockScriptReaderCloser([]byte("any-bytes"))
+		reader.On("Close").Return(nil)
+
+		execContent, err := comp.Compile(reader)
+		require.Error(t, err)
+		require.Nil(t, execContent)
+		require.ErrorIs(t, err, ErrValidationFailed)
+		require.ErrorContains(t, err, "entry point function 'no_such_fn' not found")
+		plugin.AssertExpectations(t)
+		instance.AssertExpectations(t)
+		reader.AssertExpectations(t)
+	})
+}
+
+// readCloseErr is an io.ReadCloser that delegates Read to a *bytes.Reader and
+// returns a configured error from Close. Used to exercise the scriptReader.Close
+// failure branch without involving the testify mock machinery.
+type readCloseErr struct {
+	buf      *bytes.Reader
+	closeErr error
+}
+
+func (r *readCloseErr) Read(p []byte) (int, error) {
+	return r.buf.Read(p)
+}
+
+func (r *readCloseErr) Close() error {
+	return r.closeErr
 }

--- a/engines/extism/compiler/mocks_test.go
+++ b/engines/extism/compiler/mocks_test.go
@@ -1,0 +1,76 @@
+package compiler
+
+import (
+	"context"
+
+	extismSDK "github.com/extism/go-sdk"
+	"github.com/robbyt/go-polyscript/engines/extism/adapters"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockCompiledPlugin implements adapters.CompiledPlugin for testing the Compile()
+// branches that depend on plugin.Instance(...) outcomes.
+type mockCompiledPlugin struct {
+	mock.Mock
+}
+
+func (m *mockCompiledPlugin) Instance(
+	ctx context.Context,
+	config extismSDK.PluginInstanceConfig,
+) (adapters.PluginInstance, error) {
+	args := m.Called(ctx, config)
+	inst, _ := args.Get(0).(adapters.PluginInstance)
+	return inst, args.Error(1)
+}
+
+func (m *mockCompiledPlugin) Close(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+// mockPluginInstance implements adapters.PluginInstance for testing the Compile()
+// branches that depend on FunctionExists / Close outcomes.
+type mockPluginInstance struct {
+	mock.Mock
+}
+
+func (m *mockPluginInstance) Call(name string, data []byte) (uint32, []byte, error) {
+	args := m.Called(name, data)
+	out, _ := args.Get(1).([]byte)
+	return uint32(args.Int(0)), out, args.Error(2)
+}
+
+func (m *mockPluginInstance) CallWithContext(
+	ctx context.Context,
+	name string,
+	data []byte,
+) (uint32, []byte, error) {
+	args := m.Called(ctx, name, data)
+	out, _ := args.Get(1).([]byte)
+	return uint32(args.Int(0)), out, args.Error(2)
+}
+
+func (m *mockPluginInstance) FunctionExists(name string) bool {
+	args := m.Called(name)
+	return args.Bool(0)
+}
+
+func (m *mockPluginInstance) Close(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+// errReader is an io.ReadCloser whose Read returns a configured error, so tests
+// can drive the io.ReadAll failure branch in Compile().
+type errReader struct {
+	readErr  error
+	closeErr error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	return 0, r.readErr
+}
+
+func (r *errReader) Close() error {
+	return r.closeErr
+}

--- a/engines/extism/compiler/options.go
+++ b/engines/extism/compiler/options.go
@@ -136,6 +136,11 @@ func (c *Compiler) applyDefaults() {
 	if c.ctx == nil {
 		c.ctx = context.Background()
 	}
+
+	// Default compile function (test seam); production path is compile.CompileBytes
+	if c.compileFn == nil {
+		c.compileFn = compile.CompileBytes
+	}
 }
 
 // setupLogger configures the logger and handler based on the current state.


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for error paths in the `Compiler.Compile()` method that are difficult or impossible to reach through the real Extism SDK. It introduces a test seam (`compileFn`) to allow injection of mock compile functions, enabling controlled testing of failure scenarios.

## Key Changes

- **Added test seam for compile function**: Introduced `compileFunc` type and `compileFn` field to `Compiler` struct, allowing tests to inject mock compile implementations while defaulting to `compile.CompileBytes` in production
- **New comprehensive test suite**: Added `TestCompiler_Compile_Branches()` that exercises previously untested error paths:
  - `io.ReadAll` failure during script reading
  - `scriptReader.Close()` failure
  - Compile function returning nil plugin without error
  - `plugin.Instance()` failure during validation
  - `instance.Close()` error handling (logged but not propagated)
  - Missing entry point function detection
- **New mock implementations**: Created `mocks_test.go` with:
  - `mockCompiledPlugin`: Implements `adapters.CompiledPlugin` interface
  - `mockPluginInstance`: Implements `adapters.PluginInstance` interface
  - `errReader`: Simple `io.ReadCloser` for driving read failures
  - `readCloseErr`: Delegates reads to `bytes.Reader` while returning configurable close errors
- **Simplified executable creation logic**: Removed unnecessary nil check for `NewExecutable()` result with clarifying comment explaining why it cannot return nil given the validated inputs
- **Updated compile function call**: Changed from direct `compile.CompileBytes()` call to use the injected `compileFn` field

## Implementation Details

The test seam is initialized in `applyDefaults()` to maintain backward compatibility—production code uses `compile.CompileBytes` while tests can override with mocks. The new tests use testify's mock framework to verify expected interactions and error propagation, ensuring robust error handling across all failure scenarios.

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL