### PR TITLE
rename machine -> engine for all internal terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appends to the compiler's existing globals, deduplicating names already
   present. Order-of-call no longer matters when combined with
   `WithCtxGlobal`. ([#118](https://github.com/robbyt/go-polyscript/pull/118))
+- **Breaking:** Renamed `machine`→`engine` in the type-system API to match
+  the terminology used everywhere else. `ExecutableContent.GetMachineType()`
+  and `ExecutableUnit.GetMachineType()` are now `EngineType()`. The
+  `engines/types` package exports `ErrInvalidEngineType`,
+  `GetEngineTypeFromString`, and `GetEngineTypeFromPath` (renamed from the
+  `MachineType` equivalents). The conventional import alias is now
+  `engineTypes`. ([#90](https://github.com/robbyt/go-polyscript/issues/90))
 
 ### Deprecated
 - The twelve legacy top-level constructors (`FromRisorFile`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `engines/types` package exports `ErrInvalidEngineType`,
   `GetEngineTypeFromString`, and `GetEngineTypeFromPath` (renamed from the
   `MachineType` equivalents). The conventional import alias is now
-  `engineTypes`. ([#90](https://github.com/robbyt/go-polyscript/issues/90))
+  `engineTypes`. Closes [#90](https://github.com/robbyt/go-polyscript/issues/90).
+  ([#137](https://github.com/robbyt/go-polyscript/pull/137))
 
 ### Deprecated
 - The twelve legacy top-level constructors (`FromRisorFile`,

--- a/engines/extism/compiler/executable.go
+++ b/engines/extism/compiler/executable.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/robbyt/go-polyscript/engines/extism/adapters"
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 )
 
 var ErrExecutableClosed = errors.New("executable is closed")
@@ -56,9 +56,9 @@ func (e *Executable) GetExtismByteCode() adapters.CompiledPlugin {
 	return e.ByteCode
 }
 
-// GetMachineType returns the Extism machine type
-func (e *Executable) GetMachineType() machineTypes.Type {
-	return machineTypes.Extism
+// EngineType returns the Extism engine type
+func (e *Executable) EngineType() engineTypes.Type {
+	return engineTypes.Extism
 }
 
 // GetEntryPoint returns the name of the entry point function

--- a/engines/extism/compiler/executable_test.go
+++ b/engines/extism/compiler/executable_test.go
@@ -6,7 +6,7 @@ import (
 
 	extismSDK "github.com/extism/go-sdk"
 	"github.com/robbyt/go-polyscript/engines/extism/adapters"
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -83,7 +83,7 @@ func TestExecutable(t *testing.T) {
 			assert.Equal(t, string(wasmBytes), exe.GetSource())
 			assert.Equal(t, mockPlugin, exe.GetByteCode())
 			assert.Equal(t, mockPlugin, exe.GetExtismByteCode())
-			assert.Equal(t, machineTypes.Extism, exe.GetMachineType())
+			assert.Equal(t, engineTypes.Extism, exe.EngineType())
 			assert.Equal(t, entryPoint, exe.GetEntryPoint())
 			assert.False(t, exe.closed.Load())
 		})
@@ -128,9 +128,9 @@ func TestExecutable(t *testing.T) {
 			assert.Equal(t, mockPlugin, bytecode)
 		})
 
-		t.Run("GetMachineType", func(t *testing.T) {
-			machineType := exe.GetMachineType()
-			assert.Equal(t, machineTypes.Extism, machineType)
+		t.Run("EngineType", func(t *testing.T) {
+			engineType := exe.EngineType()
+			assert.Equal(t, engineTypes.Extism, engineType)
 		})
 
 		t.Run("GetEntryPoint", func(t *testing.T) {

--- a/engines/extism/evaluator/evaluator_test.go
+++ b/engines/extism/evaluator/evaluator_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/robbyt/go-polyscript/engines/extism/adapters"
 	"github.com/robbyt/go-polyscript/engines/extism/compiler"
 	"github.com/robbyt/go-polyscript/engines/extism/internal"
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/robbyt/go-polyscript/platform/constants"
 	"github.com/robbyt/go-polyscript/platform/data"
 	"github.com/robbyt/go-polyscript/platform/script"
@@ -128,13 +128,13 @@ func (m *mockPluginInstance) Close(ctx context.Context) error {
 }
 
 type mockExecutableContent struct {
-	machineType machineTypes.Type
-	source      string
-	bytecode    any
+	engineType engineTypes.Type
+	source     string
+	bytecode   any
 }
 
-func (m *mockExecutableContent) GetMachineType() machineTypes.Type {
-	return m.machineType
+func (m *mockExecutableContent) EngineType() engineTypes.Type {
+	return m.engineType
 }
 
 func (m *mockExecutableContent) GetSource() string {
@@ -332,9 +332,9 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		// Test nil bytecode
 		t.Run("nil bytecode", func(t *testing.T) {
 			mockContent := &mockExecutableContent{
-				machineType: machineTypes.Extism,
-				source:      "invalid wasm",
-				bytecode:    nil, // Nil bytecode will cause error
+				engineType: engineTypes.Extism,
+				source:     "invalid wasm",
+				bytecode:   nil, // Nil bytecode will cause error
 			}
 
 			handler := slog.NewTextHandler(os.Stdout, nil)
@@ -358,9 +358,9 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		// Test invalid content type
 		t.Run("invalid content type", func(t *testing.T) {
 			mockContent := &mockExecutableContent{
-				machineType: machineTypes.Extism,
-				source:      "invalid wasm",
-				bytecode:    []byte{0x00}, // Not a valid WASM plugin
+				engineType: engineTypes.Extism,
+				source:     "invalid wasm",
+				bytecode:   []byte{0x00}, // Not a valid WASM plugin
 			}
 
 			handler := slog.NewTextHandler(os.Stdout, nil)

--- a/engines/risor/compiler/executable.go
+++ b/engines/risor/compiler/executable.go
@@ -2,7 +2,7 @@ package compiler
 
 import (
 	"github.com/deepnoodle-ai/risor/v2/pkg/bytecode"
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 )
 
 type executable struct {
@@ -33,6 +33,6 @@ func (e *executable) GetRisorByteCode() *bytecode.Code {
 	return e.ByteCode
 }
 
-func (e *executable) GetMachineType() machineTypes.Type {
-	return machineTypes.Risor
+func (e *executable) EngineType() engineTypes.Type {
+	return engineTypes.Risor
 }

--- a/engines/risor/compiler/executable_test.go
+++ b/engines/risor/compiler/executable_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/deepnoodle-ai/risor/v2/pkg/bytecode"
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +24,7 @@ func TestExecutable(t *testing.T) {
 			assert.Equal(t, content, exe.GetSource())
 			assert.Equal(t, bc, exe.GetByteCode())
 			assert.Equal(t, bc, exe.GetRisorByteCode())
-			assert.Equal(t, machineTypes.Risor, exe.GetMachineType())
+			assert.Equal(t, engineTypes.Risor, exe.EngineType())
 		})
 
 		t.Run("nil content", func(t *testing.T) {
@@ -71,9 +71,9 @@ func TestExecutable(t *testing.T) {
 			assert.Equal(t, bc, code)
 		})
 
-		t.Run("GetMachineType", func(t *testing.T) {
-			machineType := executable.GetMachineType()
-			assert.Equal(t, machineTypes.Risor, machineType)
+		t.Run("EngineType", func(t *testing.T) {
+			engineType := executable.EngineType()
+			assert.Equal(t, engineTypes.Risor, engineType)
 		})
 	})
 }

--- a/engines/risor/evaluator/evaluator_test.go
+++ b/engines/risor/evaluator/evaluator_test.go
@@ -76,7 +76,7 @@ func (m *MockContent) GetByteCode() any {
 	return m.Content
 }
 
-func (m *MockContent) GetMachineType() types.Type {
+func (m *MockContent) EngineType() types.Type {
 	return types.Risor
 }
 

--- a/engines/starlark/compiler/executable.go
+++ b/engines/starlark/compiler/executable.go
@@ -1,7 +1,7 @@
 package compiler
 
 import (
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	starlarkLib "go.starlark.net/starlark"
 )
 
@@ -35,6 +35,6 @@ func (e *executable) GetStarlarkByteCode() *starlarkLib.Program {
 	return e.ByteCode
 }
 
-func (e *executable) GetMachineType() machineTypes.Type {
-	return machineTypes.Starlark
+func (e *executable) EngineType() engineTypes.Type {
+	return engineTypes.Starlark
 }

--- a/engines/starlark/compiler/executable_test.go
+++ b/engines/starlark/compiler/executable_test.go
@@ -3,7 +3,7 @@ package compiler
 import (
 	"testing"
 
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	starlarkLib "go.starlark.net/starlark"
@@ -24,7 +24,7 @@ func TestExecutable(t *testing.T) {
 			assert.Equal(t, content, exe.GetSource())
 			assert.Equal(t, bytecode, exe.GetByteCode())
 			assert.Equal(t, bytecode, exe.GetStarlarkByteCode())
-			assert.Equal(t, machineTypes.Starlark, exe.GetMachineType())
+			assert.Equal(t, engineTypes.Starlark, exe.EngineType())
 		})
 
 		t.Run("nil content", func(t *testing.T) {
@@ -71,9 +71,9 @@ func TestExecutable(t *testing.T) {
 			assert.Equal(t, bytecode, code)
 		})
 
-		t.Run("GetMachineType", func(t *testing.T) {
-			machineType := executable.GetMachineType()
-			assert.Equal(t, machineTypes.Starlark, machineType)
+		t.Run("EngineType", func(t *testing.T) {
+			engineType := executable.EngineType()
+			assert.Equal(t, engineTypes.Starlark, engineType)
 		})
 	})
 }

--- a/engines/types/gen/templates/type.go.tmpl
+++ b/engines/types/gen/templates/type.go.tmpl
@@ -10,7 +10,7 @@ import (
     "strings"
 )
 
-var ErrInvalidMachineType = errors.New("invalid machine type")
+var ErrInvalidEngineType = errors.New("invalid engine type")
 
 type Type string
 
@@ -27,21 +27,21 @@ const (
     {{- end}}
 )
 
-func GetMachineTypeFromString(machineType string) (Type, error) {
-    machineType = strings.ToLower(strings.TrimSpace(machineType))
-    machineType = strings.TrimPrefix(machineType, ".")
+func GetEngineTypeFromString(engineType string) (Type, error) {
+    engineType = strings.ToLower(strings.TrimSpace(engineType))
+    engineType = strings.TrimPrefix(engineType, ".")
 
-    switch machineType {
+    switch engineType {
     {{- range .Types}}
     case "{{.Value}}":
         return {{.Name}}, nil
     {{- end}}
     default:
-        return "", fmt.Errorf("%w: %s", ErrInvalidMachineType, machineType)
+        return "", fmt.Errorf("%w: %s", ErrInvalidEngineType, engineType)
     }
 }
 
-func GetMachineTypeFromPath(path string) (Type, error) {
+func GetEngineTypeFromPath(path string) (Type, error) {
     ext := strings.TrimSpace(strings.ToLower(strings.TrimSpace(filepath.Ext(path))))
-    return GetMachineTypeFromString(ext)
+    return GetEngineTypeFromString(ext)
 }

--- a/engines/types/gen/templates/type_test.go.tmpl
+++ b/engines/types/gen/templates/type_test.go.tmpl
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMachineTypeFromString(t *testing.T) {
+func TestGetEngineTypeFromString(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -17,20 +17,20 @@ func TestGetMachineTypeFromString(t *testing.T) {
 	}{
 {{- range .Types}}
 		{
-			name:        "valid machine type {{.Name}}",
+			name:        "valid engine type {{.Name}}",
 			input:       "{{.Name}}",
 			expected:    {{.Name}},
 			expectError: false,
 		},
 {{- end}}
 		{
-			name:        "invalid machine type",
+			name:        "invalid engine type",
 			input:       "invalid",
 			expected:    "",
 			expectError: true,
 		},
 		{
-			name:        "empty machine type",
+			name:        "empty engine type",
 			input:       "",
 			expected:    "",
 			expectError: true,
@@ -40,7 +40,7 @@ func TestGetMachineTypeFromString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
-			result, err := GetMachineTypeFromString(tt.input)
+			result, err := GetEngineTypeFromString(tt.input)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -51,7 +51,7 @@ func TestGetMachineTypeFromString(t *testing.T) {
 	}
 }
 
-func TestGetMachineTypeFromPath(t *testing.T) {
+func TestGetEngineTypeFromPath(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -89,7 +89,7 @@ func TestGetMachineTypeFromPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
-			result, err := GetMachineTypeFromPath(tt.input)
+			result, err := GetEngineTypeFromPath(tt.input)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/engines/types/type.go
+++ b/engines/types/type.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-var ErrInvalidMachineType = errors.New("invalid machine type")
+var ErrInvalidEngineType = errors.New("invalid engine type")
 
 type Type string
 
@@ -28,11 +28,11 @@ const (
 	Extism Type = "extism"
 )
 
-func GetMachineTypeFromString(machineType string) (Type, error) {
-	machineType = strings.ToLower(strings.TrimSpace(machineType))
-	machineType = strings.TrimPrefix(machineType, ".")
+func GetEngineTypeFromString(engineType string) (Type, error) {
+	engineType = strings.ToLower(strings.TrimSpace(engineType))
+	engineType = strings.TrimPrefix(engineType, ".")
 
-	switch machineType {
+	switch engineType {
 	case "risor":
 		return Risor, nil
 	case "starlark":
@@ -40,11 +40,11 @@ func GetMachineTypeFromString(machineType string) (Type, error) {
 	case "extism":
 		return Extism, nil
 	default:
-		return "", fmt.Errorf("%w: %s", ErrInvalidMachineType, machineType)
+		return "", fmt.Errorf("%w: %s", ErrInvalidEngineType, engineType)
 	}
 }
 
-func GetMachineTypeFromPath(path string) (Type, error) {
+func GetEngineTypeFromPath(path string) (Type, error) {
 	ext := strings.TrimSpace(strings.ToLower(strings.TrimSpace(filepath.Ext(path))))
-	return GetMachineTypeFromString(ext)
+	return GetEngineTypeFromString(ext)
 }

--- a/engines/types/type_test.go
+++ b/engines/types/type_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetMachineTypeFromString(t *testing.T) {
+func TestGetEngineTypeFromString(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -16,31 +16,31 @@ func TestGetMachineTypeFromString(t *testing.T) {
 		expectError bool
 	}{
 		{
-			name:        "valid machine type Risor",
+			name:        "valid engine type Risor",
 			input:       "Risor",
 			expected:    Risor,
 			expectError: false,
 		},
 		{
-			name:        "valid machine type Starlark",
+			name:        "valid engine type Starlark",
 			input:       "Starlark",
 			expected:    Starlark,
 			expectError: false,
 		},
 		{
-			name:        "valid machine type Extism",
+			name:        "valid engine type Extism",
 			input:       "Extism",
 			expected:    Extism,
 			expectError: false,
 		},
 		{
-			name:        "invalid machine type",
+			name:        "invalid engine type",
 			input:       "invalid",
 			expected:    "",
 			expectError: true,
 		},
 		{
-			name:        "empty machine type",
+			name:        "empty engine type",
 			input:       "",
 			expected:    "",
 			expectError: true,
@@ -50,7 +50,7 @@ func TestGetMachineTypeFromString(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
-			result, err := GetMachineTypeFromString(tt.input)
+			result, err := GetEngineTypeFromString(tt.input)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -61,7 +61,7 @@ func TestGetMachineTypeFromString(t *testing.T) {
 	}
 }
 
-func TestGetMachineTypeFromPath(t *testing.T) {
+func TestGetEngineTypeFromPath(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
@@ -121,7 +121,7 @@ func TestGetMachineTypeFromPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
-			result, err := GetMachineTypeFromPath(tt.input)
+			result, err := GetEngineTypeFromPath(tt.input)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {

--- a/platform/script/executableContent.go
+++ b/platform/script/executableContent.go
@@ -1,7 +1,7 @@
 package script
 
 import (
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 )
 
 // ExecutableContent represents validated script content that is ready for execution or compilation.
@@ -19,6 +19,6 @@ type ExecutableContent interface {
 	// an error at runtime, so the engine type and ByteCode must be compatible.
 	GetByteCode() any
 
-	// GetMachineType returns the engine type this script is intended to run on.
-	GetMachineType() machineTypes.Type
+	// EngineType returns the engine type this script is intended to run on.
+	EngineType() engineTypes.Type
 }

--- a/platform/script/executableContent_test.go
+++ b/platform/script/executableContent_test.go
@@ -3,7 +3,7 @@ package script
 import (
 	"testing"
 
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,13 +30,13 @@ func TestExecutableContent(t *testing.T) {
 		mockContent.AssertExpectations(t)
 	})
 
-	t.Run("GetMachineType", func(t *testing.T) {
+	t.Run("EngineType", func(t *testing.T) {
 		mockContent := new(MockExecutableContent)
-		expectedType := machineTypes.Risor
-		mockContent.On("GetMachineType").Return(expectedType)
+		expectedType := engineTypes.Risor
+		mockContent.On("EngineType").Return(expectedType)
 
-		machineType := mockContent.GetMachineType()
-		require.Equal(t, expectedType, machineType, "Expected machine type to match")
+		engineType := mockContent.EngineType()
+		require.Equal(t, expectedType, engineType, "Expected engine type to match")
 		mockContent.AssertExpectations(t)
 	})
 }

--- a/platform/script/executableUnit.go
+++ b/platform/script/executableUnit.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"time"
 
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/robbyt/go-polyscript/internal/helpers"
 	"github.com/robbyt/go-polyscript/platform/data"
 	"github.com/robbyt/go-polyscript/platform/script/loader"
@@ -108,9 +108,9 @@ func (exe *ExecutableUnit) GetCreatedAt() time.Time {
 	return exe.CreatedAt
 }
 
-// GetMachineType returns the machine type this script is intended to run on.
-func (exe *ExecutableUnit) GetMachineType() machineTypes.Type {
-	return exe.Content.GetMachineType()
+// EngineType returns the engine type this script is intended to run on.
+func (exe *ExecutableUnit) EngineType() engineTypes.Type {
+	return exe.Content.EngineType()
 }
 
 // GetCompiler returns the compiler used to validate the script and convert it into runnable bytecode.

--- a/platform/script/executableUnit_test.go
+++ b/platform/script/executableUnit_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/robbyt/go-polyscript/platform/data"
 	"github.com/robbyt/go-polyscript/platform/script/loader"
 	"github.com/stretchr/testify/mock"
@@ -49,17 +49,17 @@ func (m *mockReadCloser) Close() error {
 }
 
 func TestVersionMethods(t *testing.T) {
-	t.Run("GetMachineType", func(t *testing.T) {
+	t.Run("EngineType", func(t *testing.T) {
 		mockContent := new(MockExecutableContent)
-		expectedType := machineTypes.Risor
-		mockContent.On("GetMachineType").Return(expectedType)
+		expectedType := engineTypes.Risor
+		mockContent.On("EngineType").Return(expectedType)
 
 		exe := &ExecutableUnit{
 			Content: mockContent,
 		}
 
-		machineType := exe.GetMachineType()
-		require.Equal(t, expectedType, machineType, "Expected machine type to match")
+		engineType := exe.EngineType()
+		require.Equal(t, expectedType, engineType, "Expected engine type to match")
 		mockContent.AssertExpectations(t)
 	})
 

--- a/platform/script/mocks.go
+++ b/platform/script/mocks.go
@@ -3,7 +3,7 @@ package script
 import (
 	"io"
 
-	machineTypes "github.com/robbyt/go-polyscript/engines/types"
+	engineTypes "github.com/robbyt/go-polyscript/engines/types"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -37,7 +37,7 @@ func (m *MockExecutableContent) GetByteCode() any {
 	return args.Get(0)
 }
 
-func (m *MockExecutableContent) GetMachineType() machineTypes.Type {
+func (m *MockExecutableContent) EngineType() engineTypes.Type {
 	args := m.Called()
-	return args.Get(0).(machineTypes.Type)
+	return args.Get(0).(engineTypes.Type)
 }


### PR DESCRIPTION
## Summary

Mechanical rename completing the `machine`→`engine` terminology shift that PR #45 began. The type-system surface still said "machine type"; this PR aligns it with the rest of the codebase.

**Breaking changes** (public API, pre-1.0 — landed under `[Unreleased] > Changed`):

- `ExecutableContent.GetMachineType()` → `EngineType()` (interface)
- `ExecutableUnit.GetMachineType()` → `EngineType()` (struct method)
- `engines/types.ErrInvalidMachineType` → `ErrInvalidEngineType`
- `engines/types.GetMachineTypeFromString` → `GetEngineTypeFromString`
- `engines/types.GetMachineTypeFromPath` → `GetEngineTypeFromPath`
- Conventional import alias `machineTypes` → `engineTypes` (12 files)

The code-generator templates at `engines/types/gen/templates/` were updated first, then `go generate ./engines/types/...` ran to regenerate `type.go` / `type_test.go`. Regeneration is idempotent.

**Out of scope:** The `extismMachine` / `risorMachine` / `starlarkMachine` package import aliases in `deprecated.go` and `polyscript.go` are unrelated to the type-system rename and are scheduled for #104 when `deprecated.go` is removed.

Closes #90.

## Test plan

- [x] `go generate ./engines/types/...` — runs cleanly; second run produces no diff
- [x] `grep -rn 'MachineType\|machineTypes' --include='*.go' .` — returns zero hits (acceptance criterion)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go mod tidy -diff` — no change
- [ ] CI: SonarQube quality gate, dependency-review, Copilot review

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_