### PR TITLE
docs: explain Risor vs Starlark callable-return divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signature simplified from `(*url.URL, error)` to `*url.URL`.
   ([#118](https://github.com/robbyt/go-polyscript/pull/118))
 
+### Documentation
+- Documented the intentional divergence between Risor and Starlark in how a
+  callable-returning script is handled: Risor errors, Starlark auto-invokes.
+  Added a "Script Return Value Handling" section to `engines/README.md` and
+  brief rationale comments next to each evaluator's branch.
+
 ### Fixed
 - `RequestToMap` no longer mutates the caller's `*http.Request`. The URL
   is now resolved through a local sentinel (`resolveURL`) and the body is

--- a/engines/README.md
+++ b/engines/README.md
@@ -139,6 +139,72 @@ data := map[string]any{
 }
 ```
 
+## Script Return Value Handling
+
+Each engine returns the script's final value to the caller, but they treat
+"the final value is a callable" differently. This is intentional, not an
+oversight, and reflects the source language's idioms.
+
+### Risor: callable returns are an error
+
+A Risor script's value is its last expression. If that expression evaluates
+to a function (e.g. a trailing lambda like `x => x + 1`), evaluation returns
+an error of the form `"function object returned from script: <inspect>"`.
+
+Rationale: Risor is expression-oriented (top-level expressions are normal),
+so a trailing function value is a legitimate result a script might want to
+return. Auto-invoking would guess at arity and arguments, which would surprise
+callers who genuinely meant "give me the function itself". If the script
+intends to call the function, it should do so explicitly:
+
+```risor
+let greet = func(name) { "Hello, " + name }
+greet("World")        // returns "Hello, World"
+```
+
+See `engines/risor/evaluator/evaluator.go` (`case "function":` branch).
+
+### Starlark: callable returns are auto-invoked with no args
+
+A Starlark script's value is the final assignment's value. If that value is
+a callable (a `*starlark.Function`, `*starlark.Builtin`, or any
+`starlark.Callable`), the evaluator auto-invokes it with no positional args
+and no kwargs, then returns the call's result. The returned value is frozen
+to prevent further mutation.
+
+Rationale: Starlark has no top-level expression statement, so a script body
+conventionally ends in a `def` block (followed by something like `_ = main`).
+Auto-call provides the ergonomic "run my main()" semantics that the language
+otherwise lacks.
+
+```starlark
+def greet():
+    return "Hello, World"
+_ = greet                # script returns "Hello, World"
+```
+
+See `engines/starlark/evaluator/evaluator.go` (the `starlarkLib.Callable`
+branch).
+
+### Extism / WASM: no callable-at-script-level concept
+
+The Extism engine invokes the WASM module's named entry-point function and
+returns whatever that function writes to its output buffer (JSON-decoded).
+There is no "script value" that could be a callable — the function is the
+WASM export, not a value a script can produce. This question doesn't apply.
+
+### Why they differ
+
+Both engines do the most natural thing for their host language. Forcing
+either to match the other would harm its idiomatic use:
+
+- Making Risor auto-invoke would surprise users who genuinely return functions.
+- Making Starlark refuse to auto-invoke would break the standard `def main(): ...`
+  end-of-script convention.
+
+If you need uniform behavior across engines for a specific application, call
+the function explicitly inside the script.
+
 ## Data Provider Patterns
 
 For detailed information about data provider patterns, usage examples, and best practices, see the [platform/data documentation](../platform/data/README.md).

--- a/engines/README.md
+++ b/engines/README.md
@@ -166,16 +166,18 @@ See `engines/risor/evaluator/evaluator.go` (`case "function":` branch).
 
 ### Starlark: callable returns are auto-invoked with no args
 
-A Starlark script's value is the final assignment's value. If that value is
-a callable (a `*starlark.Function`, `*starlark.Builtin`, or any
-`starlark.Callable`), the evaluator auto-invokes it with no positional args
-and no kwargs, then returns the call's result. The returned value is frozen
-to prevent further mutation.
+The Starlark evaluator pulls the script's return value out of the global
+named `_` (the standard Starlark convention for "the unused/anonymous value").
+If `_` is None or unset, it falls back to a global named `result`. If that
+final value is a callable (a `*starlark.Function`, `*starlark.Builtin`, or
+any `starlark.Callable`), the evaluator auto-invokes it with no positional
+args and no kwargs, then returns the call's result. The returned value is
+frozen via `val.Freeze()` to prevent further mutation.
 
 Rationale: Starlark has no top-level expression statement, so a script body
-conventionally ends in a `def` block (followed by something like `_ = main`).
-Auto-call provides the ergonomic "run my main()" semantics that the language
-otherwise lacks.
+conventionally ends in a `def` block followed by an assignment like
+`_ = main`. Auto-call provides the ergonomic "run my main()" semantics that
+the language otherwise lacks.
 
 ```starlark
 def greet():
@@ -183,8 +185,8 @@ def greet():
 _ = greet                # script returns "Hello, World"
 ```
 
-See `engines/starlark/evaluator/evaluator.go` (the `starlarkLib.Callable`
-branch).
+See `engines/starlark/evaluator/evaluator.go` (the `_` / `result` lookup
+plus the `starlarkLib.Callable` auto-call branch).
 
 ### Extism / WASM: no callable-at-script-level concept
 

--- a/engines/risor/evaluator/evaluator.go
+++ b/engines/risor/evaluator/evaluator.go
@@ -155,6 +155,10 @@ func (be *Evaluator) Eval(ctx context.Context) (platform.EvaluatorResponse, erro
 			ScriptResult: result.Inspect(),
 		}
 	case "function":
+		// Risor is expression-oriented; a trailing lambda is a legitimate value to
+		// return. Returning it as an error rather than auto-invoking avoids guessing
+		// arity/arguments. Diverges from Starlark by design — see engines/README.md
+		// "Script Return Value Handling".
 		return nil, &Error{
 			Msg:          fmt.Sprintf("function object returned from script: %s", result.Inspect()),
 			ScriptResult: result.Inspect(),

--- a/engines/starlark/evaluator/evaluator.go
+++ b/engines/starlark/evaluator/evaluator.go
@@ -203,7 +203,10 @@ func (be *Evaluator) Eval(ctx context.Context) (platform.EvaluatorResponse, erro
 		return result, nil
 	}
 
-	// Handle callable results (functions)
+	// Starlark has no top-level expression statement, so a script body conventionally
+	// ends in a `def` block; auto-invoke with no args matches the "run my main()"
+	// idiom. Diverges from Risor by design — see engines/README.md "Script Return
+	// Value Handling".
 	if callable, ok := result.Value.(starlarkLib.Callable); ok {
 		thread := &starlarkLib.Thread{Name: "func"}
 		val, err := starlarkLib.Call(thread, callable, nil, nil)


### PR DESCRIPTION
## Summary

Documents the intentional divergence between Risor and Starlark in how a callable-returning script is handled. No behavior change.

**The divergence:**

| Engine | Final value is a callable | Rationale |
|---|---|---|
| Risor | Errors with `"function object returned from script: ..."` | Expression-oriented; a trailing lambda is a legitimate value to return. Auto-call would guess at arity/args. |
| Starlark | Auto-invokes with no args | No top-level expression statement; scripts end in `def` by convention. Auto-call provides "run my main()" ergonomics. |
| Extism | N/A | The WASM entry-point is the function; scripts don't produce callable values. |

**Changes:**
- `engines/README.md` — new `## Script Return Value Handling` section between `## Engine-Specific Data Handling` and `## Data Provider Patterns`, with one sub-section per engine plus a "Why they differ" coda.
- `engines/risor/evaluator/evaluator.go` — brief comment above the `case "function":` branch pointing to the README section.
- `engines/starlark/evaluator/evaluator.go` — brief comment above the `starlarkLib.Callable` branch with the same pointer.
- `CHANGELOG.md` — `[Unreleased] > Documentation` entry.

Existing tests already cover both behaviors:
- Starlark auto-call: `engines/starlark/evaluator/evaluator_test.go:437-457` (the `_ = boom` pattern)
- Risor error: `engines/risor/evaluator/evaluator_test.go:615-629` (the `x => x + 1` pattern)

This closes the "Function-case alignment" backlog item as **intentional divergence, documented**.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 ./engines/risor/evaluator/ ./engines/starlark/evaluator/` green
- [x] CI: SonarQube, dependency-review, Copilot review

https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL

---
_Generated by [Claude Code](https://claude.ai/code/session_01C61VEAmjxSnX5Xhbab8NvL)_